### PR TITLE
feat: Convolution framework, edge detection filters, and morphological operations

### DIFF
--- a/include/DIPAL/DIPAL.hpp
+++ b/include/DIPAL/DIPAL.hpp
@@ -26,6 +26,10 @@
 #include "Filters/MedianFilter.hpp"
 #include "Filters/SobelFilter.hpp"
 #include "Filters/UnsharpMaskFilter.hpp"
+#include "Filters/LaplacianFilter.hpp"
+#include "Filters/PrewittFilter.hpp"
+#include "Filters/RobertsCrossFilter.hpp"
+#include "Filters/CannyFilter.hpp"
 
 // I/O Includes
 #include "IO/BMPImageIO.hpp"

--- a/include/DIPAL/DIPAL.hpp
+++ b/include/DIPAL/DIPAL.hpp
@@ -20,6 +20,8 @@
 
 // Filter includes
 #include "Filters/FilterStrategy.hpp"
+#include "Filters/Kernel.hpp"
+#include "Filters/ConvolutionFilter.hpp"
 #include "Filters/GaussianBlurFilter.hpp"
 #include "Filters/MedianFilter.hpp"
 #include "Filters/SobelFilter.hpp"

--- a/include/DIPAL/DIPAL.hpp
+++ b/include/DIPAL/DIPAL.hpp
@@ -30,6 +30,15 @@
 #include "Filters/PrewittFilter.hpp"
 #include "Filters/RobertsCrossFilter.hpp"
 #include "Filters/CannyFilter.hpp"
+#include "Filters/StructuringElement.hpp"
+#include "Filters/ErosionFilter.hpp"
+#include "Filters/DilationFilter.hpp"
+#include "Filters/OpeningFilter.hpp"
+#include "Filters/ClosingFilter.hpp"
+#include "Filters/MorphologicalGradientFilter.hpp"
+#include "Filters/TopHatFilter.hpp"
+#include "Filters/HitOrMissFilter.hpp"
+#include "Filters/SkeletonFilter.hpp"
 
 // I/O Includes
 #include "IO/BMPImageIO.hpp"

--- a/include/DIPAL/Filters/CannyFilter.hpp
+++ b/include/DIPAL/Filters/CannyFilter.hpp
@@ -1,0 +1,52 @@
+// include/DIPAL/Filters/CannyFilter.hpp
+#ifndef DIPAL_CANNY_FILTER_HPP
+#define DIPAL_CANNY_FILTER_HPP
+
+#include "FilterStrategy.hpp"
+
+namespace DIPAL {
+
+/**
+ * @brief Canny edge detector
+ *
+ * Full four-stage pipeline:
+ *   1. Gaussian smoothing
+ *   2. Sobel gradient magnitude and direction
+ *   3. Non-maximum suppression (thin edges to 1 pixel)
+ *   4. Double-threshold hysteresis (strong / weak / discard)
+ *
+ * Output is a binary-style grayscale image: 255 = edge, 0 = background.
+ * Color images are converted to grayscale before processing.
+ */
+class CannyFilter : public FilterStrategy {
+public:
+    /**
+     * @param lowThreshold   Lower hysteresis threshold  (0–255)
+     * @param highThreshold  Upper hysteresis threshold  (0–255)
+     * @param sigma          Gaussian pre-blur sigma (default 1.0)
+     * @param kernelSize     Gaussian kernel size; 0 = auto from sigma
+     */
+    CannyFilter(float lowThreshold  = 50.0f,
+                float highThreshold = 150.0f,
+                float sigma         = 1.0f,
+                int   kernelSize    = 0);
+
+    [[nodiscard]] Result<std::unique_ptr<Image>> apply(const Image& image) const override;
+    [[nodiscard]] std::string_view getName() const override;
+    [[nodiscard]] std::unique_ptr<FilterStrategy> clone() const override;
+
+    [[nodiscard]] float getLowThreshold()  const noexcept { return m_lowThreshold; }
+    [[nodiscard]] float getHighThreshold() const noexcept { return m_highThreshold; }
+    [[nodiscard]] float getSigma()         const noexcept { return m_sigma; }
+    [[nodiscard]] int   getKernelSize()    const noexcept { return m_kernelSize; }
+
+private:
+    float m_lowThreshold;
+    float m_highThreshold;
+    float m_sigma;
+    int   m_kernelSize;
+};
+
+} // namespace DIPAL
+
+#endif // DIPAL_CANNY_FILTER_HPP

--- a/include/DIPAL/Filters/ClosingFilter.hpp
+++ b/include/DIPAL/Filters/ClosingFilter.hpp
@@ -1,0 +1,28 @@
+// include/DIPAL/Filters/ClosingFilter.hpp
+#ifndef DIPAL_CLOSING_FILTER_HPP
+#define DIPAL_CLOSING_FILTER_HPP
+
+#include "FilterStrategy.hpp"
+#include "StructuringElement.hpp"
+
+namespace DIPAL {
+
+/**
+ * @brief Morphological closing  (dilation → erosion)
+ *
+ * Fills small dark holes and smooths object boundaries.
+ */
+class ClosingFilter : public FilterStrategy {
+public:
+    explicit ClosingFilter(StructuringElement se = StructuringElement::defaultElement());
+
+    [[nodiscard]] Result<std::unique_ptr<Image>> apply(const Image& image) const override;
+    [[nodiscard]] std::string_view getName() const override;
+    [[nodiscard]] std::unique_ptr<FilterStrategy> clone() const override;
+
+private:
+    StructuringElement m_se;
+};
+
+} // namespace DIPAL
+#endif // DIPAL_CLOSING_FILTER_HPP

--- a/include/DIPAL/Filters/ConvolutionFilter.hpp
+++ b/include/DIPAL/Filters/ConvolutionFilter.hpp
@@ -1,0 +1,49 @@
+// include/DIPAL/Filters/ConvolutionFilter.hpp
+#ifndef DIPAL_CONVOLUTION_FILTER_HPP
+#define DIPAL_CONVOLUTION_FILTER_HPP
+
+#include "FilterStrategy.hpp"
+#include "Kernel.hpp"
+
+#include <string>
+
+namespace DIPAL {
+
+/**
+ * @brief Generic 2D convolution filter
+ *
+ * Applies an arbitrary Kernel to grayscale or color images.
+ * Color images are processed per-channel.
+ */
+class ConvolutionFilter : public FilterStrategy {
+public:
+    /**
+     * @brief Construct a convolution filter
+     * @param kernel     The kernel to apply
+     * @param borderMode How to handle pixels near the image boundary
+     * @param name       Optional name (defaults to "ConvolutionFilter")
+     */
+    explicit ConvolutionFilter(Kernel kernel,
+                               BorderMode borderMode = BorderMode::Clamp,
+                               std::string name = "ConvolutionFilter");
+
+    [[nodiscard]] Result<std::unique_ptr<Image>> apply(const Image& image) const override;
+    [[nodiscard]] std::string_view getName() const override;
+    [[nodiscard]] std::unique_ptr<FilterStrategy> clone() const override;
+
+    [[nodiscard]] const Kernel&    getKernel()     const noexcept { return m_kernel; }
+    [[nodiscard]] BorderMode       getBorderMode() const noexcept { return m_borderMode; }
+
+private:
+    Kernel     m_kernel;
+    BorderMode m_borderMode;
+    std::string m_name;
+
+    // Resolve out-of-bounds coordinate according to BorderMode.
+    // Returns the resolved index, or -1 when BorderMode::Zero applies.
+    [[nodiscard]] int resolveCoord(int coord, int size) const noexcept;
+};
+
+} // namespace DIPAL
+
+#endif // DIPAL_CONVOLUTION_FILTER_HPP

--- a/include/DIPAL/Filters/DilationFilter.hpp
+++ b/include/DIPAL/Filters/DilationFilter.hpp
@@ -1,0 +1,31 @@
+// include/DIPAL/Filters/DilationFilter.hpp
+#ifndef DIPAL_DILATION_FILTER_HPP
+#define DIPAL_DILATION_FILTER_HPP
+
+#include "FilterStrategy.hpp"
+#include "StructuringElement.hpp"
+
+namespace DIPAL {
+
+/**
+ * @brief Morphological dilation
+ *
+ * Each output pixel is the maximum of the input pixels covered by the
+ * structuring element.  Works on grayscale and colour (per-channel).
+ */
+class DilationFilter : public FilterStrategy {
+public:
+    explicit DilationFilter(StructuringElement se = StructuringElement::defaultElement());
+
+    [[nodiscard]] Result<std::unique_ptr<Image>> apply(const Image& image) const override;
+    [[nodiscard]] std::string_view getName() const override;
+    [[nodiscard]] std::unique_ptr<FilterStrategy> clone() const override;
+
+    [[nodiscard]] const StructuringElement& getStructuringElement() const noexcept { return m_se; }
+
+private:
+    StructuringElement m_se;
+};
+
+} // namespace DIPAL
+#endif // DIPAL_DILATION_FILTER_HPP

--- a/include/DIPAL/Filters/ErosionFilter.hpp
+++ b/include/DIPAL/Filters/ErosionFilter.hpp
@@ -1,0 +1,31 @@
+// include/DIPAL/Filters/ErosionFilter.hpp
+#ifndef DIPAL_EROSION_FILTER_HPP
+#define DIPAL_EROSION_FILTER_HPP
+
+#include "FilterStrategy.hpp"
+#include "StructuringElement.hpp"
+
+namespace DIPAL {
+
+/**
+ * @brief Morphological erosion
+ *
+ * Each output pixel is the minimum of the input pixels covered by the
+ * structuring element.  Works on grayscale and colour (per-channel).
+ */
+class ErosionFilter : public FilterStrategy {
+public:
+    explicit ErosionFilter(StructuringElement se = StructuringElement::defaultElement());
+
+    [[nodiscard]] Result<std::unique_ptr<Image>> apply(const Image& image) const override;
+    [[nodiscard]] std::string_view getName() const override;
+    [[nodiscard]] std::unique_ptr<FilterStrategy> clone() const override;
+
+    [[nodiscard]] const StructuringElement& getStructuringElement() const noexcept { return m_se; }
+
+private:
+    StructuringElement m_se;
+};
+
+} // namespace DIPAL
+#endif // DIPAL_EROSION_FILTER_HPP

--- a/include/DIPAL/Filters/Filters.hpp
+++ b/include/DIPAL/Filters/Filters.hpp
@@ -9,5 +9,9 @@
 #include "MedianFilter.hpp"
 #include "SobelFilter.hpp"
 #include "UnsharpMaskFilter.hpp"
+#include "LaplacianFilter.hpp"
+#include "PrewittFilter.hpp"
+#include "RobertsCrossFilter.hpp"
+#include "CannyFilter.hpp"
 
 #endif  // DIPAL_FILTERS_HPP

--- a/include/DIPAL/Filters/Filters.hpp
+++ b/include/DIPAL/Filters/Filters.hpp
@@ -13,5 +13,14 @@
 #include "PrewittFilter.hpp"
 #include "RobertsCrossFilter.hpp"
 #include "CannyFilter.hpp"
+#include "StructuringElement.hpp"
+#include "ErosionFilter.hpp"
+#include "DilationFilter.hpp"
+#include "OpeningFilter.hpp"
+#include "ClosingFilter.hpp"
+#include "MorphologicalGradientFilter.hpp"
+#include "TopHatFilter.hpp"
+#include "HitOrMissFilter.hpp"
+#include "SkeletonFilter.hpp"
 
 #endif  // DIPAL_FILTERS_HPP

--- a/include/DIPAL/Filters/Filters.hpp
+++ b/include/DIPAL/Filters/Filters.hpp
@@ -2,5 +2,12 @@
 #ifndef DIPAL_FILTERS_HPP
 #define DIPAL_FILTERS_HPP
 
+#include "FilterStrategy.hpp"
+#include "Kernel.hpp"
+#include "ConvolutionFilter.hpp"
+#include "GaussianBlurFilter.hpp"
+#include "MedianFilter.hpp"
+#include "SobelFilter.hpp"
+#include "UnsharpMaskFilter.hpp"
 
 #endif  // DIPAL_FILTERS_HPP

--- a/include/DIPAL/Filters/HitOrMissFilter.hpp
+++ b/include/DIPAL/Filters/HitOrMissFilter.hpp
@@ -1,0 +1,35 @@
+// include/DIPAL/Filters/HitOrMissFilter.hpp
+#ifndef DIPAL_HIT_OR_MISS_FILTER_HPP
+#define DIPAL_HIT_OR_MISS_FILTER_HPP
+
+#include "FilterStrategy.hpp"
+#include "StructuringElement.hpp"
+
+namespace DIPAL {
+
+/**
+ * @brief Hit-or-Miss transform
+ *
+ * Detects pixels that match a foreground structuring element AND whose
+ * complement matches a background structuring element simultaneously.
+ * Input is treated as binary (threshold 128).  Output: 255 = match, 0 = no match.
+ */
+class HitOrMissFilter : public FilterStrategy {
+public:
+    /**
+     * @param foreground  SE applied to the image (pixels that must be ON)
+     * @param background  SE applied to the complement (pixels that must be OFF)
+     */
+    HitOrMissFilter(StructuringElement foreground, StructuringElement background);
+
+    [[nodiscard]] Result<std::unique_ptr<Image>> apply(const Image& image) const override;
+    [[nodiscard]] std::string_view getName() const override;
+    [[nodiscard]] std::unique_ptr<FilterStrategy> clone() const override;
+
+private:
+    StructuringElement m_foreground;
+    StructuringElement m_background;
+};
+
+} // namespace DIPAL
+#endif // DIPAL_HIT_OR_MISS_FILTER_HPP

--- a/include/DIPAL/Filters/Kernel.hpp
+++ b/include/DIPAL/Filters/Kernel.hpp
@@ -1,0 +1,96 @@
+// include/DIPAL/Filters/Kernel.hpp
+#ifndef DIPAL_KERNEL_HPP
+#define DIPAL_KERNEL_HPP
+
+#include <vector>
+#include <span>
+#include <stdexcept>
+#include <format>
+#include <cmath>
+#include <numbers>
+
+namespace DIPAL {
+
+/**
+ * @brief Border handling mode for convolution
+ */
+enum class BorderMode {
+    Clamp,    // Clamp coordinates to image boundary (replicate border pixels)
+    Reflect,  // Reflect kernel indices at the boundary
+    Wrap,     // Wrap around (tile)
+    Zero,     // Treat out-of-bounds pixels as zero
+};
+
+/**
+ * @brief A 2D convolution kernel
+ *
+ * Stores floating-point weights in row-major order.
+ * Width and height must both be odd and positive.
+ */
+class Kernel {
+public:
+    /**
+     * @brief Construct a kernel from a flat weight vector
+     * @param width  Kernel width (must be odd and > 0)
+     * @param height Kernel height (must be odd and > 0)
+     * @param weights Row-major weights (size must equal width * height)
+     */
+    Kernel(int width, int height, std::vector<float> weights);
+
+    [[nodiscard]] int getWidth()  const noexcept { return m_width; }
+    [[nodiscard]] int getHeight() const noexcept { return m_height; }
+    [[nodiscard]] int getHalfWidth()  const noexcept { return m_width  / 2; }
+    [[nodiscard]] int getHalfHeight() const noexcept { return m_height / 2; }
+
+    [[nodiscard]] float at(int row, int col) const noexcept {
+        return m_weights[static_cast<size_t>(row) * m_width + col];
+    }
+
+    [[nodiscard]] std::span<const float> weights() const noexcept { return m_weights; }
+
+    // -------------------------------------------------------------------------
+    // Factory methods for common kernels
+    // -------------------------------------------------------------------------
+
+    /** 3x3 box (mean) blur */
+    [[nodiscard]] static Kernel box(int size = 3);
+
+    /** Gaussian blur kernel */
+    [[nodiscard]] static Kernel gaussian(float sigma, int size = 0);
+
+    /** 3x3 sharpening kernel */
+    [[nodiscard]] static Kernel sharpen();
+
+    /** 3x3 Laplacian (4-neighbour) */
+    [[nodiscard]] static Kernel laplacian4();
+
+    /** 3x3 Laplacian (8-neighbour) */
+    [[nodiscard]] static Kernel laplacian8();
+
+    /** 3x3 Prewitt X gradient */
+    [[nodiscard]] static Kernel prewittX();
+
+    /** 3x3 Prewitt Y gradient */
+    [[nodiscard]] static Kernel prewittY();
+
+    /** 2x2 Roberts Cross X */
+    [[nodiscard]] static Kernel robertsCrossX();
+
+    /** 2x2 Roberts Cross Y */
+    [[nodiscard]] static Kernel robertsCrossY();
+
+    /** 3x3 emboss */
+    [[nodiscard]] static Kernel emboss();
+
+    /** 3x3 edge-enhance */
+    [[nodiscard]] static Kernel edgeEnhance();
+
+private:
+    int m_width;
+    int m_height;
+    std::vector<float> m_weights;
+};
+
+} // namespace DIPAL
+
+#endif // DIPAL_KERNEL_HPP

--- a/include/DIPAL/Filters/LaplacianFilter.hpp
+++ b/include/DIPAL/Filters/LaplacianFilter.hpp
@@ -1,0 +1,37 @@
+// include/DIPAL/Filters/LaplacianFilter.hpp
+#ifndef DIPAL_LAPLACIAN_FILTER_HPP
+#define DIPAL_LAPLACIAN_FILTER_HPP
+
+#include "FilterStrategy.hpp"
+
+namespace DIPAL {
+
+/**
+ * @brief Laplacian edge detection filter
+ *
+ * Applies the discrete Laplacian operator to detect edges and regions of
+ * rapid intensity change.  Color images are converted to grayscale first.
+ */
+class LaplacianFilter : public FilterStrategy {
+public:
+    /**
+     * @param use8Neighbor  false = 4-neighbour kernel, true = 8-neighbour kernel
+     * @param normalize     Normalize output to [0, 255] range
+     */
+    explicit LaplacianFilter(bool use8Neighbor = false, bool normalize = true);
+
+    [[nodiscard]] Result<std::unique_ptr<Image>> apply(const Image& image) const override;
+    [[nodiscard]] std::string_view getName() const override;
+    [[nodiscard]] std::unique_ptr<FilterStrategy> clone() const override;
+
+    [[nodiscard]] bool isUsing8Neighbor() const noexcept { return m_use8Neighbor; }
+    [[nodiscard]] bool isNormalized()     const noexcept { return m_normalize; }
+
+private:
+    bool m_use8Neighbor;
+    bool m_normalize;
+};
+
+} // namespace DIPAL
+
+#endif // DIPAL_LAPLACIAN_FILTER_HPP

--- a/include/DIPAL/Filters/MorphologicalGradientFilter.hpp
+++ b/include/DIPAL/Filters/MorphologicalGradientFilter.hpp
@@ -1,0 +1,28 @@
+// include/DIPAL/Filters/MorphologicalGradientFilter.hpp
+#ifndef DIPAL_MORPHOLOGICAL_GRADIENT_FILTER_HPP
+#define DIPAL_MORPHOLOGICAL_GRADIENT_FILTER_HPP
+
+#include "FilterStrategy.hpp"
+#include "StructuringElement.hpp"
+
+namespace DIPAL {
+
+/**
+ * @brief Morphological gradient  (dilation − erosion)
+ *
+ * Highlights object boundaries.
+ */
+class MorphologicalGradientFilter : public FilterStrategy {
+public:
+    explicit MorphologicalGradientFilter(StructuringElement se = StructuringElement::defaultElement());
+
+    [[nodiscard]] Result<std::unique_ptr<Image>> apply(const Image& image) const override;
+    [[nodiscard]] std::string_view getName() const override;
+    [[nodiscard]] std::unique_ptr<FilterStrategy> clone() const override;
+
+private:
+    StructuringElement m_se;
+};
+
+} // namespace DIPAL
+#endif // DIPAL_MORPHOLOGICAL_GRADIENT_FILTER_HPP

--- a/include/DIPAL/Filters/OpeningFilter.hpp
+++ b/include/DIPAL/Filters/OpeningFilter.hpp
@@ -1,0 +1,28 @@
+// include/DIPAL/Filters/OpeningFilter.hpp
+#ifndef DIPAL_OPENING_FILTER_HPP
+#define DIPAL_OPENING_FILTER_HPP
+
+#include "FilterStrategy.hpp"
+#include "StructuringElement.hpp"
+
+namespace DIPAL {
+
+/**
+ * @brief Morphological opening  (erosion → dilation)
+ *
+ * Removes small bright objects and smooths object boundaries.
+ */
+class OpeningFilter : public FilterStrategy {
+public:
+    explicit OpeningFilter(StructuringElement se = StructuringElement::defaultElement());
+
+    [[nodiscard]] Result<std::unique_ptr<Image>> apply(const Image& image) const override;
+    [[nodiscard]] std::string_view getName() const override;
+    [[nodiscard]] std::unique_ptr<FilterStrategy> clone() const override;
+
+private:
+    StructuringElement m_se;
+};
+
+} // namespace DIPAL
+#endif // DIPAL_OPENING_FILTER_HPP

--- a/include/DIPAL/Filters/PrewittFilter.hpp
+++ b/include/DIPAL/Filters/PrewittFilter.hpp
@@ -1,0 +1,34 @@
+// include/DIPAL/Filters/PrewittFilter.hpp
+#ifndef DIPAL_PREWITT_FILTER_HPP
+#define DIPAL_PREWITT_FILTER_HPP
+
+#include "FilterStrategy.hpp"
+
+namespace DIPAL {
+
+/**
+ * @brief Prewitt edge detection filter
+ *
+ * Computes gradient magnitude from horizontal and vertical Prewitt operators.
+ * Color images are converted to grayscale first.
+ */
+class PrewittFilter : public FilterStrategy {
+public:
+    /**
+     * @param normalize  Normalize output to [0, 255] range
+     */
+    explicit PrewittFilter(bool normalize = true);
+
+    [[nodiscard]] Result<std::unique_ptr<Image>> apply(const Image& image) const override;
+    [[nodiscard]] std::string_view getName() const override;
+    [[nodiscard]] std::unique_ptr<FilterStrategy> clone() const override;
+
+    [[nodiscard]] bool isNormalized() const noexcept { return m_normalize; }
+
+private:
+    bool m_normalize;
+};
+
+} // namespace DIPAL
+
+#endif // DIPAL_PREWITT_FILTER_HPP

--- a/include/DIPAL/Filters/RobertsCrossFilter.hpp
+++ b/include/DIPAL/Filters/RobertsCrossFilter.hpp
@@ -1,0 +1,34 @@
+// include/DIPAL/Filters/RobertsCrossFilter.hpp
+#ifndef DIPAL_ROBERTS_CROSS_FILTER_HPP
+#define DIPAL_ROBERTS_CROSS_FILTER_HPP
+
+#include "FilterStrategy.hpp"
+
+namespace DIPAL {
+
+/**
+ * @brief Roberts Cross edge detection filter
+ *
+ * Computes gradient magnitude using the 2x2 Roberts Cross diagonal operators
+ * (embedded in 3x3 kernels).  Color images are converted to grayscale first.
+ */
+class RobertsCrossFilter : public FilterStrategy {
+public:
+    /**
+     * @param normalize  Normalize output to [0, 255] range
+     */
+    explicit RobertsCrossFilter(bool normalize = true);
+
+    [[nodiscard]] Result<std::unique_ptr<Image>> apply(const Image& image) const override;
+    [[nodiscard]] std::string_view getName() const override;
+    [[nodiscard]] std::unique_ptr<FilterStrategy> clone() const override;
+
+    [[nodiscard]] bool isNormalized() const noexcept { return m_normalize; }
+
+private:
+    bool m_normalize;
+};
+
+} // namespace DIPAL
+
+#endif // DIPAL_ROBERTS_CROSS_FILTER_HPP

--- a/include/DIPAL/Filters/SkeletonFilter.hpp
+++ b/include/DIPAL/Filters/SkeletonFilter.hpp
@@ -1,0 +1,34 @@
+// include/DIPAL/Filters/SkeletonFilter.hpp
+#ifndef DIPAL_SKELETON_FILTER_HPP
+#define DIPAL_SKELETON_FILTER_HPP
+
+#include "FilterStrategy.hpp"
+
+namespace DIPAL {
+
+/**
+ * @brief Morphological skeleton / thinning via Zhang-Suen algorithm
+ *
+ * Reduces binary foreground objects to 1-pixel-wide skeletons while
+ * preserving topology.  Input is thresholded at 128 before processing.
+ * Output: 255 = skeleton pixel, 0 = background.
+ */
+class SkeletonFilter : public FilterStrategy {
+public:
+    /**
+     * @param threshold  Binarisation threshold applied to the input (default 128)
+     */
+    explicit SkeletonFilter(uint8_t threshold = 128);
+
+    [[nodiscard]] Result<std::unique_ptr<Image>> apply(const Image& image) const override;
+    [[nodiscard]] std::string_view getName() const override;
+    [[nodiscard]] std::unique_ptr<FilterStrategy> clone() const override;
+
+    [[nodiscard]] uint8_t getThreshold() const noexcept { return m_threshold; }
+
+private:
+    uint8_t m_threshold;
+};
+
+} // namespace DIPAL
+#endif // DIPAL_SKELETON_FILTER_HPP

--- a/include/DIPAL/Filters/StructuringElement.hpp
+++ b/include/DIPAL/Filters/StructuringElement.hpp
@@ -1,0 +1,57 @@
+// include/DIPAL/Filters/StructuringElement.hpp
+#ifndef DIPAL_STRUCTURING_ELEMENT_HPP
+#define DIPAL_STRUCTURING_ELEMENT_HPP
+
+#include <vector>
+
+namespace DIPAL {
+
+/**
+ * @brief Structuring element for morphological operations
+ *
+ * Stores a 2D binary mask. Width and height must be odd and positive.
+ */
+class StructuringElement {
+public:
+    enum class Shape { Rect, Ellipse, Cross, Diamond };
+
+    /** Construct from an explicit boolean mask (row-major, width*height entries). */
+    StructuringElement(int width, int height, std::vector<bool> mask);
+
+    [[nodiscard]] int  getWidth()      const noexcept { return m_width; }
+    [[nodiscard]] int  getHeight()     const noexcept { return m_height; }
+    [[nodiscard]] int  getHalfWidth()  const noexcept { return m_width  / 2; }
+    [[nodiscard]] int  getHalfHeight() const noexcept { return m_height / 2; }
+
+    [[nodiscard]] bool at(int row, int col) const noexcept {
+        return m_mask[static_cast<size_t>(row * m_width + col)];
+    }
+
+    // -------------------------------------------------------------------------
+    // Factory methods
+    // -------------------------------------------------------------------------
+
+    /** Filled rectangle */
+    [[nodiscard]] static StructuringElement rect(int width, int height);
+
+    /** Filled ellipse inscribed in width × height */
+    [[nodiscard]] static StructuringElement ellipse(int width, int height);
+
+    /** Plus-shaped cross of given size (must be odd) */
+    [[nodiscard]] static StructuringElement cross(int size);
+
+    /** Diamond (rhombus) of given size (must be odd) */
+    [[nodiscard]] static StructuringElement diamond(int size);
+
+    /** 3×3 rect — the most common default */
+    [[nodiscard]] static StructuringElement defaultElement();
+
+private:
+    int              m_width;
+    int              m_height;
+    std::vector<bool> m_mask;
+};
+
+} // namespace DIPAL
+
+#endif // DIPAL_STRUCTURING_ELEMENT_HPP

--- a/include/DIPAL/Filters/TopHatFilter.hpp
+++ b/include/DIPAL/Filters/TopHatFilter.hpp
@@ -1,0 +1,35 @@
+// include/DIPAL/Filters/TopHatFilter.hpp
+#ifndef DIPAL_TOP_HAT_FILTER_HPP
+#define DIPAL_TOP_HAT_FILTER_HPP
+
+#include "FilterStrategy.hpp"
+#include "StructuringElement.hpp"
+
+namespace DIPAL {
+
+/**
+ * @brief Top-hat transform
+ *
+ * White top-hat: original − opening  (extracts small bright features)
+ * Black top-hat: closing − original  (extracts small dark features)
+ */
+class TopHatFilter : public FilterStrategy {
+public:
+    enum class Type { White, Black };
+
+    explicit TopHatFilter(Type type = Type::White,
+                          StructuringElement se = StructuringElement::defaultElement());
+
+    [[nodiscard]] Result<std::unique_ptr<Image>> apply(const Image& image) const override;
+    [[nodiscard]] std::string_view getName() const override;
+    [[nodiscard]] std::unique_ptr<FilterStrategy> clone() const override;
+
+    [[nodiscard]] Type getType() const noexcept { return m_type; }
+
+private:
+    Type               m_type;
+    StructuringElement m_se;
+};
+
+} // namespace DIPAL
+#endif // DIPAL_TOP_HAT_FILTER_HPP

--- a/src/Filters/CannyFilter.cpp
+++ b/src/Filters/CannyFilter.cpp
@@ -1,0 +1,226 @@
+// src/Filters/CannyFilter.cpp
+#include "../../include/DIPAL/Filters/CannyFilter.hpp"
+#include "../../include/DIPAL/Filters/GaussianBlurFilter.hpp"
+#include "../../include/DIPAL/Image/GrayscaleImage.hpp"
+#include "../../include/DIPAL/Image/ColorImage.hpp"
+#include "../../include/DIPAL/Image/ImageFactory.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <format>
+#include <numbers>
+#include <queue>
+#include <vector>
+
+namespace DIPAL {
+
+CannyFilter::CannyFilter(float lowThreshold, float highThreshold, float sigma, int kernelSize)
+    : m_lowThreshold(lowThreshold)
+    , m_highThreshold(highThreshold)
+    , m_sigma(sigma)
+    , m_kernelSize(kernelSize)
+{}
+
+Result<std::unique_ptr<Image>> CannyFilter::apply(const Image& image) const {
+    const int width  = image.getWidth();
+    const int height = image.getHeight();
+
+    if (width == 0 || height == 0) {
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::InvalidParameter,
+            "Cannot apply Canny filter to an empty image");
+    }
+
+    try {
+        // ---------------------------------------------------------------
+        // Stage 1: Convert to grayscale
+        // ---------------------------------------------------------------
+        std::unique_ptr<GrayscaleImage> gray;
+        if (image.getType() == Image::Type::Grayscale) {
+            auto c = image.clone();
+            gray.reset(static_cast<GrayscaleImage*>(c.release()));
+        } else if (image.getType() == Image::Type::RGB ||
+                   image.getType() == Image::Type::RGBA) {
+            auto r = ImageFactory::toGrayscale(static_cast<const ColorImage&>(image));
+            if (!r)
+                return makeErrorResult<std::unique_ptr<Image>>(
+                    r.error().code(), r.error().message());
+            gray = std::move(r.value());
+        } else {
+            return makeErrorResult<std::unique_ptr<Image>>(
+                ErrorCode::UnsupportedFormat,
+                std::format("CannyFilter: unsupported image type {}",
+                            static_cast<int>(image.getType())));
+        }
+
+        // ---------------------------------------------------------------
+        // Stage 2: Gaussian smoothing
+        // ---------------------------------------------------------------
+        int kSize = m_kernelSize;
+        if (kSize <= 0)
+            kSize = static_cast<int>(std::ceil(6.0f * m_sigma)) | 1;
+        if (kSize % 2 == 0)
+            ++kSize;
+
+        GaussianBlurFilter gaussFilter(m_sigma, kSize);
+        auto blurResult = gaussFilter.apply(*gray);
+        if (!blurResult)
+            return makeErrorResult<std::unique_ptr<Image>>(
+                blurResult.error().code(), blurResult.error().message());
+        auto& blurred = static_cast<GrayscaleImage&>(*blurResult.value());
+
+        // ---------------------------------------------------------------
+        // Stage 3: Sobel gradient magnitude and direction
+        // ---------------------------------------------------------------
+        const int sobelX[3][3] = {{-1, 0, 1}, {-2, 0, 2}, {-1, 0, 1}};
+        const int sobelY[3][3] = {{-1,-2,-1}, { 0, 0, 0}, { 1, 2, 1}};
+
+        std::vector<float> magnitude(static_cast<size_t>(width * height), 0.0f);
+        std::vector<float> direction(static_cast<size_t>(width * height), 0.0f);
+
+        for (int y = 0; y < height; ++y) {
+            for (int x = 0; x < width; ++x) {
+                float gx = 0.0f, gy = 0.0f;
+                for (int ky = -1; ky <= 1; ++ky) {
+                    for (int kx = -1; kx <= 1; ++kx) {
+                        const int sy = std::clamp(y + ky, 0, height - 1);
+                        const int sx = std::clamp(x + kx, 0, width  - 1);
+                        auto pr = blurred.getPixel(sx, sy);
+                        if (!pr)
+                            return makeErrorResult<std::unique_ptr<Image>>(
+                                pr.error().code(), pr.error().message());
+                        const float p = static_cast<float>(pr.value());
+                        gx += sobelX[ky + 1][kx + 1] * p;
+                        gy += sobelY[ky + 1][kx + 1] * p;
+                    }
+                }
+                const size_t idx = static_cast<size_t>(y * width + x);
+                magnitude[idx] = std::sqrt(gx * gx + gy * gy);
+                direction[idx] = std::atan2(gy, gx);
+            }
+        }
+
+        // ---------------------------------------------------------------
+        // Stage 4: Non-maximum suppression
+        // ---------------------------------------------------------------
+        std::vector<float> suppressed(static_cast<size_t>(width * height), 0.0f);
+
+        for (int y = 1; y < height - 1; ++y) {
+            for (int x = 1; x < width - 1; ++x) {
+                const size_t idx = static_cast<size_t>(y * width + x);
+                const float  mag = magnitude[idx];
+                // Quantise angle to 0°, 45°, 90°, 135°
+                float angle = direction[idx] * (180.0f / std::numbers::pi_v<float>);
+                if (angle < 0.0f) angle += 180.0f;
+
+                float mag1 = 0.0f, mag2 = 0.0f;
+                if (angle < 22.5f || angle >= 157.5f) {
+                    // 0° — horizontal edge
+                    mag1 = magnitude[static_cast<size_t>(y * width + (x - 1))];
+                    mag2 = magnitude[static_cast<size_t>(y * width + (x + 1))];
+                } else if (angle < 67.5f) {
+                    // 45°
+                    mag1 = magnitude[static_cast<size_t>((y - 1) * width + (x + 1))];
+                    mag2 = magnitude[static_cast<size_t>((y + 1) * width + (x - 1))];
+                } else if (angle < 112.5f) {
+                    // 90° — vertical edge
+                    mag1 = magnitude[static_cast<size_t>((y - 1) * width + x)];
+                    mag2 = magnitude[static_cast<size_t>((y + 1) * width + x)];
+                } else {
+                    // 135°
+                    mag1 = magnitude[static_cast<size_t>((y - 1) * width + (x - 1))];
+                    mag2 = magnitude[static_cast<size_t>((y + 1) * width + (x + 1))];
+                }
+
+                suppressed[idx] = (mag >= mag1 && mag >= mag2) ? mag : 0.0f;
+            }
+        }
+
+        // ---------------------------------------------------------------
+        // Stage 5: Double-threshold hysteresis
+        // ---------------------------------------------------------------
+        // Pixel states: 0 = background, 128 = weak, 255 = strong
+        auto outResult = ImageFactory::createGrayscale(width, height);
+        if (!outResult)
+            return makeErrorResult<std::unique_ptr<Image>>(
+                outResult.error().code(), outResult.error().message());
+        auto& out = *outResult.value();
+
+        constexpr uint8_t kStrong = 255;
+        constexpr uint8_t kWeak   = 128;
+
+        std::queue<std::pair<int,int>> strongQueue;
+
+        for (int y = 0; y < height; ++y) {
+            for (int x = 0; x < width; ++x) {
+                const float mag = suppressed[static_cast<size_t>(y * width + x)];
+                uint8_t val = 0;
+                if (mag >= m_highThreshold) {
+                    val = kStrong;
+                    strongQueue.push({x, y});
+                } else if (mag >= m_lowThreshold) {
+                    val = kWeak;
+                }
+                auto sr = out.setPixel(x, y, val);
+                if (!sr)
+                    return makeErrorResult<std::unique_ptr<Image>>(
+                        sr.error().code(), sr.error().message());
+            }
+        }
+
+        // BFS from strong pixels — promote connected weak pixels
+        const int dx[8] = {-1, 0, 1, -1, 1, -1, 0, 1};
+        const int dy[8] = {-1,-1,-1,  0, 0,  1, 1, 1};
+
+        while (!strongQueue.empty()) {
+            auto [cx, cy] = strongQueue.front();
+            strongQueue.pop();
+
+            for (int d = 0; d < 8; ++d) {
+                const int nx = cx + dx[d];
+                const int ny = cy + dy[d];
+                if (nx < 0 || nx >= width || ny < 0 || ny >= height)
+                    continue;
+
+                auto pr = out.getPixel(nx, ny);
+                if (!pr || pr.value() != kWeak)
+                    continue;
+
+                auto sr = out.setPixel(nx, ny, kStrong);
+                if (!sr)
+                    return makeErrorResult<std::unique_ptr<Image>>(
+                        sr.error().code(), sr.error().message());
+                strongQueue.push({nx, ny});
+            }
+        }
+
+        // Clear remaining weak pixels
+        for (int y = 0; y < height; ++y) {
+            for (int x = 0; x < width; ++x) {
+                auto pr = out.getPixel(x, y);
+                if (pr && pr.value() == kWeak) {
+                    auto sr = out.setPixel(x, y, 0);
+                    if (!sr)
+                        return makeErrorResult<std::unique_ptr<Image>>(
+                            sr.error().code(), sr.error().message());
+                }
+            }
+        }
+
+        return makeSuccessResult<std::unique_ptr<Image>>(std::move(outResult.value()));
+
+    } catch (const std::exception& e) {
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::ProcessingFailed,
+            std::format("CannyFilter failed: {}", e.what()));
+    }
+}
+
+std::string_view CannyFilter::getName() const { return "CannyFilter"; }
+
+std::unique_ptr<FilterStrategy> CannyFilter::clone() const {
+    return std::make_unique<CannyFilter>(
+        m_lowThreshold, m_highThreshold, m_sigma, m_kernelSize);
+}
+
+} // namespace DIPAL

--- a/src/Filters/ClosingFilter.cpp
+++ b/src/Filters/ClosingFilter.cpp
@@ -1,0 +1,26 @@
+// src/Filters/ClosingFilter.cpp
+#include "../../include/DIPAL/Filters/ClosingFilter.hpp"
+#include "../../include/DIPAL/Filters/ErosionFilter.hpp"
+#include "../../include/DIPAL/Filters/DilationFilter.hpp"
+
+namespace DIPAL {
+
+ClosingFilter::ClosingFilter(StructuringElement se) : m_se(std::move(se)) {}
+
+Result<std::unique_ptr<Image>> ClosingFilter::apply(const Image& image) const {
+    DilationFilter dilate(m_se);
+    ErosionFilter  erode(m_se);
+
+    auto dilated = dilate.apply(image);
+    if (!dilated) return dilated;
+
+    return erode.apply(*dilated.value());
+}
+
+std::string_view ClosingFilter::getName() const { return "ClosingFilter"; }
+
+std::unique_ptr<FilterStrategy> ClosingFilter::clone() const {
+    return std::make_unique<ClosingFilter>(m_se);
+}
+
+} // namespace DIPAL

--- a/src/Filters/ConvolutionFilter.cpp
+++ b/src/Filters/ConvolutionFilter.cpp
@@ -1,0 +1,181 @@
+// src/Filters/ConvolutionFilter.cpp
+#include "../../include/DIPAL/Filters/ConvolutionFilter.hpp"
+#include "../../include/DIPAL/Image/GrayscaleImage.hpp"
+#include "../../include/DIPAL/Image/ColorImage.hpp"
+#include "../../include/DIPAL/Image/ImageFactory.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <format>
+
+namespace DIPAL {
+
+ConvolutionFilter::ConvolutionFilter(Kernel kernel, BorderMode borderMode, std::string name)
+    : m_kernel(std::move(kernel))
+    , m_borderMode(borderMode)
+    , m_name(std::move(name))
+{}
+
+std::string_view ConvolutionFilter::getName() const {
+    return m_name;
+}
+
+std::unique_ptr<FilterStrategy> ConvolutionFilter::clone() const {
+    return std::make_unique<ConvolutionFilter>(m_kernel, m_borderMode, m_name);
+}
+
+int ConvolutionFilter::resolveCoord(int coord, int size) const noexcept {
+    if (coord >= 0 && coord < size)
+        return coord;
+
+    switch (m_borderMode) {
+        case BorderMode::Clamp:
+            return std::clamp(coord, 0, size - 1);
+
+        case BorderMode::Reflect: {
+            if (coord < 0)
+                return -coord - 1;
+            // coord >= size
+            return 2 * size - coord - 1;
+        }
+
+        case BorderMode::Wrap: {
+            int r = coord % size;
+            return r < 0 ? r + size : r;
+        }
+
+        case BorderMode::Zero:
+            return -1; // sentinel: use 0.0f for this pixel
+    }
+    return std::clamp(coord, 0, size - 1);
+}
+
+Result<std::unique_ptr<Image>> ConvolutionFilter::apply(const Image& image) const {
+    const int width  = image.getWidth();
+    const int height = image.getHeight();
+
+    if (width == 0 || height == 0) {
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::InvalidParameter,
+            "Cannot apply convolution to an empty image");
+    }
+
+    const int halfW = m_kernel.getHalfWidth();
+    const int halfH = m_kernel.getHalfHeight();
+    const int kW    = m_kernel.getWidth();
+    const int kH    = m_kernel.getHeight();
+
+    try {
+        if (image.getType() == Image::Type::Grayscale) {
+            const auto& src = static_cast<const GrayscaleImage&>(image);
+
+            auto outResult = ImageFactory::createGrayscale(width, height);
+            if (!outResult)
+                return makeErrorResult<std::unique_ptr<Image>>(
+                    outResult.error().code(), outResult.error().message());
+            auto& out = *outResult.value();
+
+            for (int y = 0; y < height; ++y) {
+                for (int x = 0; x < width; ++x) {
+                    float acc = 0.0f;
+                    for (int ky = 0; ky < kH; ++ky) {
+                        for (int kx = 0; kx < kW; ++kx) {
+                            const int sy = resolveCoord(y + ky - halfH, height);
+                            const int sx = resolveCoord(x + kx - halfW, width);
+
+                            float pix = 0.0f;
+                            if (sy >= 0 && sx >= 0) {
+                                auto pr = src.getPixel(sx, sy);
+                                if (!pr)
+                                    return makeErrorResult<std::unique_ptr<Image>>(
+                                        pr.error().code(), pr.error().message());
+                                pix = static_cast<float>(pr.value());
+                            }
+                            acc += m_kernel.at(ky, kx) * pix;
+                        }
+                    }
+
+                    const auto val = static_cast<uint8_t>(
+                        std::clamp(std::round(acc), 0.0f, 255.0f));
+                    auto sr = out.setPixel(x, y, val);
+                    if (!sr)
+                        return makeErrorResult<std::unique_ptr<Image>>(
+                            sr.error().code(), sr.error().message());
+                }
+            }
+            return makeSuccessResult<std::unique_ptr<Image>>(std::move(outResult.value()));
+        }
+
+        if (image.getType() == Image::Type::RGB || image.getType() == Image::Type::RGBA) {
+            const auto& src = static_cast<const ColorImage&>(image);
+            const bool  hasAlpha = (image.getType() == Image::Type::RGBA);
+
+            auto outResult = ImageFactory::createColor(width, height, hasAlpha);
+            if (!outResult)
+                return makeErrorResult<std::unique_ptr<Image>>(
+                    outResult.error().code(), outResult.error().message());
+            auto& out = *outResult.value();
+
+            for (int y = 0; y < height; ++y) {
+                for (int x = 0; x < width; ++x) {
+                    float accR = 0.0f, accG = 0.0f, accB = 0.0f;
+
+                    for (int ky = 0; ky < kH; ++ky) {
+                        for (int kx = 0; kx < kW; ++kx) {
+                            const int sy = resolveCoord(y + ky - halfH, height);
+                            const int sx = resolveCoord(x + kx - halfW, width);
+
+                            float pr = 0.0f, pg = 0.0f, pb = 0.0f;
+                            if (sy >= 0 && sx >= 0) {
+                                uint8_t r, g, b, a;
+                                auto gr = src.getPixel(sx, sy, r, g, b, a);
+                                if (!gr)
+                                    return makeErrorResult<std::unique_ptr<Image>>(
+                                        gr.error().code(), gr.error().message());
+                                pr = static_cast<float>(r);
+                                pg = static_cast<float>(g);
+                                pb = static_cast<float>(b);
+                            }
+                            const float w = m_kernel.at(ky, kx);
+                            accR += w * pr;
+                            accG += w * pg;
+                            accB += w * pb;
+                        }
+                    }
+
+                    // Fetch original alpha for pass-through
+                    uint8_t origR, origG, origB, origA;
+                    auto ga = src.getPixel(x, y, origR, origG, origB, origA);
+                    if (!ga)
+                        return makeErrorResult<std::unique_ptr<Image>>(
+                            ga.error().code(), ga.error().message());
+
+                    const uint8_t outR = static_cast<uint8_t>(
+                        std::clamp(std::round(accR), 0.0f, 255.0f));
+                    const uint8_t outG = static_cast<uint8_t>(
+                        std::clamp(std::round(accG), 0.0f, 255.0f));
+                    const uint8_t outB = static_cast<uint8_t>(
+                        std::clamp(std::round(accB), 0.0f, 255.0f));
+
+                    auto sr = out.setPixel(x, y, outR, outG, outB, origA);
+                    if (!sr)
+                        return makeErrorResult<std::unique_ptr<Image>>(
+                            sr.error().code(), sr.error().message());
+                }
+            }
+            return makeSuccessResult<std::unique_ptr<Image>>(std::move(outResult.value()));
+        }
+
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::UnsupportedFormat,
+            std::format("ConvolutionFilter: unsupported image type {}",
+                        static_cast<int>(image.getType())));
+
+    } catch (const std::exception& e) {
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::ProcessingFailed,
+            std::format("ConvolutionFilter failed: {}", e.what()));
+    }
+}
+
+} // namespace DIPAL

--- a/src/Filters/DilationFilter.cpp
+++ b/src/Filters/DilationFilter.cpp
@@ -1,0 +1,113 @@
+// src/Filters/DilationFilter.cpp
+#include "../../include/DIPAL/Filters/DilationFilter.hpp"
+#include "../../include/DIPAL/Image/GrayscaleImage.hpp"
+#include "../../include/DIPAL/Image/ColorImage.hpp"
+#include "../../include/DIPAL/Image/ImageFactory.hpp"
+
+#include <algorithm>
+#include <format>
+
+namespace DIPAL {
+
+DilationFilter::DilationFilter(StructuringElement se) : m_se(std::move(se)) {}
+
+Result<std::unique_ptr<Image>> DilationFilter::apply(const Image& image) const {
+    const int width  = image.getWidth();
+    const int height = image.getHeight();
+
+    if (width == 0 || height == 0)
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::InvalidParameter, "Cannot dilate an empty image");
+
+    const int halfW = m_se.getHalfWidth();
+    const int halfH = m_se.getHalfHeight();
+    const int kW    = m_se.getWidth();
+    const int kH    = m_se.getHeight();
+
+    try {
+        if (image.getType() == Image::Type::Grayscale) {
+            const auto& src = static_cast<const GrayscaleImage&>(image);
+            auto outR = ImageFactory::createGrayscale(width, height);
+            if (!outR) return makeErrorResult<std::unique_ptr<Image>>(
+                outR.error().code(), outR.error().message());
+            auto& out = *outR.value();
+
+            for (int y = 0; y < height; ++y) {
+                for (int x = 0; x < width; ++x) {
+                    uint8_t maxVal = 0;
+                    for (int ky = 0; ky < kH; ++ky) {
+                        for (int kx = 0; kx < kW; ++kx) {
+                            if (!m_se.at(ky, kx)) continue;
+                            const int sy = std::clamp(y + ky - halfH, 0, height - 1);
+                            const int sx = std::clamp(x + kx - halfW, 0, width  - 1);
+                            auto pr = src.getPixel(sx, sy);
+                            if (!pr) return makeErrorResult<std::unique_ptr<Image>>(
+                                pr.error().code(), pr.error().message());
+                            maxVal = std::max(maxVal, pr.value());
+                        }
+                    }
+                    auto sr = out.setPixel(x, y, maxVal);
+                    if (!sr) return makeErrorResult<std::unique_ptr<Image>>(
+                        sr.error().code(), sr.error().message());
+                }
+            }
+            return makeSuccessResult<std::unique_ptr<Image>>(std::move(outR.value()));
+        }
+
+        if (image.getType() == Image::Type::RGB || image.getType() == Image::Type::RGBA) {
+            const auto& src  = static_cast<const ColorImage&>(image);
+            const bool  hasA = (image.getType() == Image::Type::RGBA);
+            auto outR = ImageFactory::createColor(width, height, hasA);
+            if (!outR) return makeErrorResult<std::unique_ptr<Image>>(
+                outR.error().code(), outR.error().message());
+            auto& out = *outR.value();
+
+            for (int y = 0; y < height; ++y) {
+                for (int x = 0; x < width; ++x) {
+                    uint8_t maxR = 0, maxG = 0, maxB = 0;
+                    for (int ky = 0; ky < kH; ++ky) {
+                        for (int kx = 0; kx < kW; ++kx) {
+                            if (!m_se.at(ky, kx)) continue;
+                            const int sy = std::clamp(y + ky - halfH, 0, height - 1);
+                            const int sx = std::clamp(x + kx - halfW, 0, width  - 1);
+                            uint8_t r, g, b, a;
+                            auto pr = src.getPixel(sx, sy, r, g, b, a);
+                            if (!pr) return makeErrorResult<std::unique_ptr<Image>>(
+                                pr.error().code(), pr.error().message());
+                            maxR = std::max(maxR, r);
+                            maxG = std::max(maxG, g);
+                            maxB = std::max(maxB, b);
+                        }
+                    }
+                    // Preserve alpha from center pixel
+                    uint8_t cr, cg, cb, ca;
+                    auto cp = src.getPixel(x, y, cr, cg, cb, ca);
+                    if (!cp) return makeErrorResult<std::unique_ptr<Image>>(
+                        cp.error().code(), cp.error().message());
+                    auto sr = out.setPixel(x, y, maxR, maxG, maxB, ca);
+                    if (!sr) return makeErrorResult<std::unique_ptr<Image>>(
+                        sr.error().code(), sr.error().message());
+                }
+            }
+            return makeSuccessResult<std::unique_ptr<Image>>(std::move(outR.value()));
+        }
+
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::UnsupportedFormat,
+            std::format("DilationFilter: unsupported image type {}",
+                        static_cast<int>(image.getType())));
+
+    } catch (const std::exception& e) {
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::ProcessingFailed,
+            std::format("DilationFilter failed: {}", e.what()));
+    }
+}
+
+std::string_view DilationFilter::getName() const { return "DilationFilter"; }
+
+std::unique_ptr<FilterStrategy> DilationFilter::clone() const {
+    return std::make_unique<DilationFilter>(m_se);
+}
+
+} // namespace DIPAL

--- a/src/Filters/ErosionFilter.cpp
+++ b/src/Filters/ErosionFilter.cpp
@@ -1,0 +1,114 @@
+// src/Filters/ErosionFilter.cpp
+#include "../../include/DIPAL/Filters/ErosionFilter.hpp"
+#include "../../include/DIPAL/Image/GrayscaleImage.hpp"
+#include "../../include/DIPAL/Image/ColorImage.hpp"
+#include "../../include/DIPAL/Image/ImageFactory.hpp"
+
+#include <algorithm>
+#include <format>
+#include <limits>
+
+namespace DIPAL {
+
+ErosionFilter::ErosionFilter(StructuringElement se) : m_se(std::move(se)) {}
+
+Result<std::unique_ptr<Image>> ErosionFilter::apply(const Image& image) const {
+    const int width  = image.getWidth();
+    const int height = image.getHeight();
+
+    if (width == 0 || height == 0)
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::InvalidParameter, "Cannot erode an empty image");
+
+    const int halfW = m_se.getHalfWidth();
+    const int halfH = m_se.getHalfHeight();
+    const int kW    = m_se.getWidth();
+    const int kH    = m_se.getHeight();
+
+    try {
+        if (image.getType() == Image::Type::Grayscale) {
+            const auto& src = static_cast<const GrayscaleImage&>(image);
+            auto outR = ImageFactory::createGrayscale(width, height);
+            if (!outR) return makeErrorResult<std::unique_ptr<Image>>(
+                outR.error().code(), outR.error().message());
+            auto& out = *outR.value();
+
+            for (int y = 0; y < height; ++y) {
+                for (int x = 0; x < width; ++x) {
+                    uint8_t minVal = std::numeric_limits<uint8_t>::max();
+                    for (int ky = 0; ky < kH; ++ky) {
+                        for (int kx = 0; kx < kW; ++kx) {
+                            if (!m_se.at(ky, kx)) continue;
+                            const int sy = std::clamp(y + ky - halfH, 0, height - 1);
+                            const int sx = std::clamp(x + kx - halfW, 0, width  - 1);
+                            auto pr = src.getPixel(sx, sy);
+                            if (!pr) return makeErrorResult<std::unique_ptr<Image>>(
+                                pr.error().code(), pr.error().message());
+                            minVal = std::min(minVal, pr.value());
+                        }
+                    }
+                    auto sr = out.setPixel(x, y, minVal);
+                    if (!sr) return makeErrorResult<std::unique_ptr<Image>>(
+                        sr.error().code(), sr.error().message());
+                }
+            }
+            return makeSuccessResult<std::unique_ptr<Image>>(std::move(outR.value()));
+        }
+
+        if (image.getType() == Image::Type::RGB || image.getType() == Image::Type::RGBA) {
+            const auto& src  = static_cast<const ColorImage&>(image);
+            const bool  hasA = (image.getType() == Image::Type::RGBA);
+            auto outR = ImageFactory::createColor(width, height, hasA);
+            if (!outR) return makeErrorResult<std::unique_ptr<Image>>(
+                outR.error().code(), outR.error().message());
+            auto& out = *outR.value();
+
+            for (int y = 0; y < height; ++y) {
+                for (int x = 0; x < width; ++x) {
+                    uint8_t minR = 255, minG = 255, minB = 255;
+                    for (int ky = 0; ky < kH; ++ky) {
+                        for (int kx = 0; kx < kW; ++kx) {
+                            if (!m_se.at(ky, kx)) continue;
+                            const int sy = std::clamp(y + ky - halfH, 0, height - 1);
+                            const int sx = std::clamp(x + kx - halfW, 0, width  - 1);
+                            uint8_t r, g, b, a;
+                            auto pr = src.getPixel(sx, sy, r, g, b, a);
+                            if (!pr) return makeErrorResult<std::unique_ptr<Image>>(
+                                pr.error().code(), pr.error().message());
+                            minR = std::min(minR, r);
+                            minG = std::min(minG, g);
+                            minB = std::min(minB, b);
+                        }
+                    }
+                    // Preserve alpha from the center pixel
+                    uint8_t cr, cg, cb, ca;
+                    auto cp = src.getPixel(x, y, cr, cg, cb, ca);
+                    if (!cp) return makeErrorResult<std::unique_ptr<Image>>(
+                        cp.error().code(), cp.error().message());
+                    auto sr = out.setPixel(x, y, minR, minG, minB, ca);
+                    if (!sr) return makeErrorResult<std::unique_ptr<Image>>(
+                        sr.error().code(), sr.error().message());
+                }
+            }
+            return makeSuccessResult<std::unique_ptr<Image>>(std::move(outR.value()));
+        }
+
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::UnsupportedFormat,
+            std::format("ErosionFilter: unsupported image type {}",
+                        static_cast<int>(image.getType())));
+
+    } catch (const std::exception& e) {
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::ProcessingFailed,
+            std::format("ErosionFilter failed: {}", e.what()));
+    }
+}
+
+std::string_view ErosionFilter::getName() const { return "ErosionFilter"; }
+
+std::unique_ptr<FilterStrategy> ErosionFilter::clone() const {
+    return std::make_unique<ErosionFilter>(m_se);
+}
+
+} // namespace DIPAL

--- a/src/Filters/HitOrMissFilter.cpp
+++ b/src/Filters/HitOrMissFilter.cpp
@@ -1,0 +1,106 @@
+// src/Filters/HitOrMissFilter.cpp
+#include "../../include/DIPAL/Filters/HitOrMissFilter.hpp"
+#include "../../include/DIPAL/Image/GrayscaleImage.hpp"
+#include "../../include/DIPAL/Image/ColorImage.hpp"
+#include "../../include/DIPAL/Image/ImageFactory.hpp"
+
+#include <algorithm>
+#include <format>
+
+namespace DIPAL {
+
+HitOrMissFilter::HitOrMissFilter(StructuringElement foreground, StructuringElement background)
+    : m_foreground(std::move(foreground))
+    , m_background(std::move(background))
+{}
+
+Result<std::unique_ptr<Image>> HitOrMissFilter::apply(const Image& image) const {
+    const int width  = image.getWidth();
+    const int height = image.getHeight();
+
+    if (width == 0 || height == 0)
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::InvalidParameter, "Cannot apply Hit-or-Miss to empty image");
+
+    // Obtain a grayscale view (convert color if needed)
+    std::unique_ptr<GrayscaleImage> gray;
+    try {
+        if (image.getType() == Image::Type::Grayscale) {
+            auto c = image.clone();
+            gray.reset(static_cast<GrayscaleImage*>(c.release()));
+        } else if (image.getType() == Image::Type::RGB ||
+                   image.getType() == Image::Type::RGBA) {
+            auto r = ImageFactory::toGrayscale(static_cast<const ColorImage&>(image));
+            if (!r) return makeErrorResult<std::unique_ptr<Image>>(
+                r.error().code(), r.error().message());
+            gray = std::move(r.value());
+        } else {
+            return makeErrorResult<std::unique_ptr<Image>>(
+                ErrorCode::UnsupportedFormat,
+                std::format("HitOrMissFilter: unsupported image type {}",
+                            static_cast<int>(image.getType())));
+        }
+
+        auto outR = ImageFactory::createGrayscale(width, height);
+        if (!outR) return makeErrorResult<std::unique_ptr<Image>>(
+            outR.error().code(), outR.error().message());
+        auto& out = *outR.value();
+
+        const int fHalfW = m_foreground.getHalfWidth();
+        const int fHalfH = m_foreground.getHalfHeight();
+        const int fW     = m_foreground.getWidth();
+        const int fH     = m_foreground.getHeight();
+
+        for (int y = 0; y < height; ++y) {
+            for (int x = 0; x < width; ++x) {
+                bool match = true;
+
+                // Check foreground SE: all covered pixels must be >= 128 (ON)
+                for (int ky = 0; ky < fH && match; ++ky) {
+                    for (int kx = 0; kx < fW && match; ++kx) {
+                        if (!m_foreground.at(ky, kx)) continue;
+                        const int sy = std::clamp(y + ky - fHalfH, 0, height - 1);
+                        const int sx = std::clamp(x + kx - fHalfW, 0, width  - 1);
+                        auto pr = gray->getPixel(sx, sy);
+                        if (!pr || pr.value() < 128) match = false;
+                    }
+                }
+
+                // Check background SE: all covered pixels must be < 128 (OFF)
+                const int bHalfW = m_background.getHalfWidth();
+                const int bHalfH = m_background.getHalfHeight();
+                const int bW     = m_background.getWidth();
+                const int bH     = m_background.getHeight();
+
+                for (int ky = 0; ky < bH && match; ++ky) {
+                    for (int kx = 0; kx < bW && match; ++kx) {
+                        if (!m_background.at(ky, kx)) continue;
+                        const int sy = std::clamp(y + ky - bHalfH, 0, height - 1);
+                        const int sx = std::clamp(x + kx - bHalfW, 0, width  - 1);
+                        auto pr = gray->getPixel(sx, sy);
+                        if (!pr || pr.value() >= 128) match = false;
+                    }
+                }
+
+                auto sr = out.setPixel(x, y, match ? uint8_t{255} : uint8_t{0});
+                if (!sr) return makeErrorResult<std::unique_ptr<Image>>(
+                    sr.error().code(), sr.error().message());
+            }
+        }
+
+        return makeSuccessResult<std::unique_ptr<Image>>(std::move(outR.value()));
+
+    } catch (const std::exception& e) {
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::ProcessingFailed,
+            std::format("HitOrMissFilter failed: {}", e.what()));
+    }
+}
+
+std::string_view HitOrMissFilter::getName() const { return "HitOrMissFilter"; }
+
+std::unique_ptr<FilterStrategy> HitOrMissFilter::clone() const {
+    return std::make_unique<HitOrMissFilter>(m_foreground, m_background);
+}
+
+} // namespace DIPAL

--- a/src/Filters/Kernel.cpp
+++ b/src/Filters/Kernel.cpp
@@ -1,0 +1,136 @@
+// src/Filters/Kernel.cpp
+#include "../../include/DIPAL/Filters/Kernel.hpp"
+
+#include <stdexcept>
+#include <format>
+#include <cmath>
+#include <numbers>
+
+namespace DIPAL {
+
+Kernel::Kernel(int width, int height, std::vector<float> weights)
+    : m_width(width), m_height(height), m_weights(std::move(weights))
+{
+    if (width <= 0 || width % 2 == 0)
+        throw std::invalid_argument(
+            std::format("Kernel width must be positive and odd, got {}", width));
+    if (height <= 0 || height % 2 == 0)
+        throw std::invalid_argument(
+            std::format("Kernel height must be positive and odd, got {}", height));
+    if (static_cast<int>(m_weights.size()) != width * height)
+        throw std::invalid_argument(
+            std::format("Kernel weight count {} != width*height {}",
+                        m_weights.size(), width * height));
+}
+
+Kernel Kernel::box(int size) {
+    if (size <= 0 || size % 2 == 0)
+        throw std::invalid_argument(
+            std::format("Box kernel size must be positive and odd, got {}", size));
+    const float w = 1.0f / static_cast<float>(size * size);
+    return Kernel(size, size, std::vector<float>(static_cast<size_t>(size * size), w));
+}
+
+Kernel Kernel::gaussian(float sigma, int size) {
+    if (sigma <= 0.0f)
+        throw std::invalid_argument(
+            std::format("Gaussian sigma must be positive, got {}", sigma));
+
+    if (size <= 0)
+        size = static_cast<int>(std::ceil(6.0f * sigma)) | 1; // round up to odd
+    if (size % 2 == 0)
+        ++size;
+
+    const int half = size / 2;
+    const float twoSigSq = 2.0f * sigma * sigma;
+    std::vector<float> w(static_cast<size_t>(size * size));
+    float sum = 0.0f;
+
+    for (int r = -half; r <= half; ++r) {
+        for (int c = -half; c <= half; ++c) {
+            float val = std::exp(-(r * r + c * c) / twoSigSq);
+            w[static_cast<size_t>((r + half) * size + (c + half))] = val;
+            sum += val;
+        }
+    }
+    for (auto& v : w)
+        v /= sum;
+
+    return Kernel(size, size, std::move(w));
+}
+
+Kernel Kernel::sharpen() {
+    return Kernel(3, 3, {
+         0.0f, -1.0f,  0.0f,
+        -1.0f,  5.0f, -1.0f,
+         0.0f, -1.0f,  0.0f
+    });
+}
+
+Kernel Kernel::laplacian4() {
+    return Kernel(3, 3, {
+         0.0f,  1.0f,  0.0f,
+         1.0f, -4.0f,  1.0f,
+         0.0f,  1.0f,  0.0f
+    });
+}
+
+Kernel Kernel::laplacian8() {
+    return Kernel(3, 3, {
+         1.0f,  1.0f,  1.0f,
+         1.0f, -8.0f,  1.0f,
+         1.0f,  1.0f,  1.0f
+    });
+}
+
+Kernel Kernel::prewittX() {
+    return Kernel(3, 3, {
+        -1.0f, 0.0f, 1.0f,
+        -1.0f, 0.0f, 1.0f,
+        -1.0f, 0.0f, 1.0f
+    });
+}
+
+Kernel Kernel::prewittY() {
+    return Kernel(3, 3, {
+        -1.0f, -1.0f, -1.0f,
+         0.0f,  0.0f,  0.0f,
+         1.0f,  1.0f,  1.0f
+    });
+}
+
+// Roberts Cross kernels are 2x2, which violates the odd-size rule.
+// We embed them in a 3x3 with zero-padding so the framework stays uniform.
+Kernel Kernel::robertsCrossX() {
+    return Kernel(3, 3, {
+         1.0f,  0.0f, 0.0f,
+         0.0f, -1.0f, 0.0f,
+         0.0f,  0.0f, 0.0f
+    });
+}
+
+Kernel Kernel::robertsCrossY() {
+    return Kernel(3, 3, {
+         0.0f,  1.0f, 0.0f,
+        -1.0f,  0.0f, 0.0f,
+         0.0f,  0.0f, 0.0f
+    });
+}
+
+Kernel Kernel::emboss() {
+    return Kernel(3, 3, {
+        -2.0f, -1.0f, 0.0f,
+        -1.0f,  1.0f, 1.0f,
+         0.0f,  1.0f, 2.0f
+    });
+}
+
+Kernel Kernel::edgeEnhance() {
+    return Kernel(3, 3, {
+         0.0f,  0.0f,  0.0f,
+        -1.0f,  1.0f,  0.0f,
+         0.0f,  0.0f,  0.0f
+    });
+}
+
+} // namespace DIPAL

--- a/src/Filters/LaplacianFilter.cpp
+++ b/src/Filters/LaplacianFilter.cpp
@@ -1,0 +1,96 @@
+// src/Filters/LaplacianFilter.cpp
+#include "../../include/DIPAL/Filters/LaplacianFilter.hpp"
+#include "../../include/DIPAL/Filters/ConvolutionFilter.hpp"
+#include "../../include/DIPAL/Filters/Kernel.hpp"
+#include "../../include/DIPAL/Image/GrayscaleImage.hpp"
+#include "../../include/DIPAL/Image/ColorImage.hpp"
+#include "../../include/DIPAL/Image/ImageFactory.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <format>
+
+namespace DIPAL {
+
+LaplacianFilter::LaplacianFilter(bool use8Neighbor, bool normalize)
+    : m_use8Neighbor(use8Neighbor), m_normalize(normalize)
+{}
+
+Result<std::unique_ptr<Image>> LaplacianFilter::apply(const Image& image) const {
+    const int width  = image.getWidth();
+    const int height = image.getHeight();
+
+    if (width == 0 || height == 0) {
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::InvalidParameter,
+            "Cannot apply Laplacian filter to an empty image");
+    }
+
+    try {
+        // Convert colour → grayscale if necessary
+        std::unique_ptr<GrayscaleImage> gray;
+        if (image.getType() == Image::Type::Grayscale) {
+            auto c = image.clone();
+            gray.reset(static_cast<GrayscaleImage*>(c.release()));
+        } else if (image.getType() == Image::Type::RGB ||
+                   image.getType() == Image::Type::RGBA) {
+            auto r = ImageFactory::toGrayscale(static_cast<const ColorImage&>(image));
+            if (!r)
+                return makeErrorResult<std::unique_ptr<Image>>(
+                    r.error().code(), r.error().message());
+            gray = std::move(r.value());
+        } else {
+            return makeErrorResult<std::unique_ptr<Image>>(
+                ErrorCode::UnsupportedFormat,
+                std::format("LaplacianFilter: unsupported image type {}",
+                            static_cast<int>(image.getType())));
+        }
+
+        // Apply Laplacian kernel via ConvolutionFilter
+        const Kernel k = m_use8Neighbor ? Kernel::laplacian8() : Kernel::laplacian4();
+        ConvolutionFilter conv(k, BorderMode::Clamp, "LaplacianFilter");
+        auto convResult = conv.apply(*gray);
+        if (!convResult)
+            return convResult;
+
+        if (!m_normalize)
+            return convResult;
+
+        // Normalize to [0, 255]
+        auto& out = static_cast<GrayscaleImage&>(*convResult.value());
+        int maxVal = 0;
+        for (int y = 0; y < height; ++y)
+            for (int x = 0; x < width; ++x) {
+                auto pr = out.getPixel(x, y);
+                if (pr) maxVal = std::max(maxVal, static_cast<int>(pr.value()));
+            }
+
+        if (maxVal > 0 && maxVal < 255) {
+            for (int y = 0; y < height; ++y)
+                for (int x = 0; x < width; ++x) {
+                    auto pr = out.getPixel(x, y);
+                    if (!pr) continue;
+                    auto sr = out.setPixel(x, y,
+                        static_cast<uint8_t>((pr.value() * 255) / maxVal));
+                    if (!sr)
+                        return makeErrorResult<std::unique_ptr<Image>>(
+                            sr.error().code(), sr.error().message());
+                }
+        }
+
+        return convResult;
+
+    } catch (const std::exception& e) {
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::ProcessingFailed,
+            std::format("LaplacianFilter failed: {}", e.what()));
+    }
+}
+
+std::string_view LaplacianFilter::getName() const { return "LaplacianFilter"; }
+
+std::unique_ptr<FilterStrategy> LaplacianFilter::clone() const {
+    return std::make_unique<LaplacianFilter>(m_use8Neighbor, m_normalize);
+}
+
+} // namespace DIPAL

--- a/src/Filters/MorphologicalGradientFilter.cpp
+++ b/src/Filters/MorphologicalGradientFilter.cpp
@@ -1,0 +1,106 @@
+// src/Filters/MorphologicalGradientFilter.cpp
+#include "../../include/DIPAL/Filters/MorphologicalGradientFilter.hpp"
+#include "../../include/DIPAL/Filters/ErosionFilter.hpp"
+#include "../../include/DIPAL/Filters/DilationFilter.hpp"
+#include "../../include/DIPAL/Image/GrayscaleImage.hpp"
+#include "../../include/DIPAL/Image/ColorImage.hpp"
+#include "../../include/DIPAL/Image/ImageFactory.hpp"
+
+#include <algorithm>
+#include <format>
+
+namespace DIPAL {
+
+MorphologicalGradientFilter::MorphologicalGradientFilter(StructuringElement se)
+    : m_se(std::move(se)) {}
+
+Result<std::unique_ptr<Image>> MorphologicalGradientFilter::apply(const Image& image) const {
+    if (image.getWidth() == 0 || image.getHeight() == 0)
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::InvalidParameter, "Cannot compute morphological gradient of empty image");
+
+    DilationFilter dilate(m_se);
+    ErosionFilter  erode(m_se);
+
+    auto dilated = dilate.apply(image);
+    if (!dilated) return dilated;
+
+    auto eroded = erode.apply(image);
+    if (!eroded) return eroded;
+
+    // Subtract: gradient = dilation - erosion (per pixel, clamped to [0,255])
+    const int width  = image.getWidth();
+    const int height = image.getHeight();
+
+    try {
+        if (image.getType() == Image::Type::Grayscale) {
+            const auto& d = static_cast<const GrayscaleImage&>(*dilated.value());
+            const auto& e = static_cast<const GrayscaleImage&>(*eroded.value());
+            auto outR = ImageFactory::createGrayscale(width, height);
+            if (!outR) return makeErrorResult<std::unique_ptr<Image>>(
+                outR.error().code(), outR.error().message());
+            auto& out = *outR.value();
+
+            for (int y = 0; y < height; ++y) {
+                for (int x = 0; x < width; ++x) {
+                    auto dp = d.getPixel(x, y);
+                    auto ep = e.getPixel(x, y);
+                    if (!dp || !ep) return makeErrorResult<std::unique_ptr<Image>>(
+                        ErrorCode::ProcessingFailed, "Failed to read pixel");
+                    const uint8_t val = static_cast<uint8_t>(dp.value() - ep.value());
+                    auto sr = out.setPixel(x, y, val);
+                    if (!sr) return makeErrorResult<std::unique_ptr<Image>>(
+                        sr.error().code(), sr.error().message());
+                }
+            }
+            return makeSuccessResult<std::unique_ptr<Image>>(std::move(outR.value()));
+        }
+
+        if (image.getType() == Image::Type::RGB || image.getType() == Image::Type::RGBA) {
+            const auto& d    = static_cast<const ColorImage&>(*dilated.value());
+            const auto& e    = static_cast<const ColorImage&>(*eroded.value());
+            const bool  hasA = (image.getType() == Image::Type::RGBA);
+            auto outR = ImageFactory::createColor(width, height, hasA);
+            if (!outR) return makeErrorResult<std::unique_ptr<Image>>(
+                outR.error().code(), outR.error().message());
+            auto& out = *outR.value();
+
+            for (int y = 0; y < height; ++y) {
+                for (int x = 0; x < width; ++x) {
+                    uint8_t dr, dg, db, da, er, eg, eb, ea;
+                    auto dp = d.getPixel(x, y, dr, dg, db, da);
+                    auto ep = e.getPixel(x, y, er, eg, eb, ea);
+                    if (!dp || !ep) return makeErrorResult<std::unique_ptr<Image>>(
+                        ErrorCode::ProcessingFailed, "Failed to read pixel");
+                    auto sr = out.setPixel(x, y,
+                        static_cast<uint8_t>(dr - er),
+                        static_cast<uint8_t>(dg - eg),
+                        static_cast<uint8_t>(db - eb), da);
+                    if (!sr) return makeErrorResult<std::unique_ptr<Image>>(
+                        sr.error().code(), sr.error().message());
+                }
+            }
+            return makeSuccessResult<std::unique_ptr<Image>>(std::move(outR.value()));
+        }
+
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::UnsupportedFormat,
+            std::format("MorphologicalGradientFilter: unsupported image type {}",
+                        static_cast<int>(image.getType())));
+
+    } catch (const std::exception& e) {
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::ProcessingFailed,
+            std::format("MorphologicalGradientFilter failed: {}", e.what()));
+    }
+}
+
+std::string_view MorphologicalGradientFilter::getName() const {
+    return "MorphologicalGradientFilter";
+}
+
+std::unique_ptr<FilterStrategy> MorphologicalGradientFilter::clone() const {
+    return std::make_unique<MorphologicalGradientFilter>(m_se);
+}
+
+} // namespace DIPAL

--- a/src/Filters/OpeningFilter.cpp
+++ b/src/Filters/OpeningFilter.cpp
@@ -1,0 +1,28 @@
+// src/Filters/OpeningFilter.cpp
+#include "../../include/DIPAL/Filters/OpeningFilter.hpp"
+#include "../../include/DIPAL/Filters/ErosionFilter.hpp"
+#include "../../include/DIPAL/Filters/DilationFilter.hpp"
+
+#include <format>
+
+namespace DIPAL {
+
+OpeningFilter::OpeningFilter(StructuringElement se) : m_se(std::move(se)) {}
+
+Result<std::unique_ptr<Image>> OpeningFilter::apply(const Image& image) const {
+    ErosionFilter  erode(m_se);
+    DilationFilter dilate(m_se);
+
+    auto eroded = erode.apply(image);
+    if (!eroded) return eroded;
+
+    return dilate.apply(*eroded.value());
+}
+
+std::string_view OpeningFilter::getName() const { return "OpeningFilter"; }
+
+std::unique_ptr<FilterStrategy> OpeningFilter::clone() const {
+    return std::make_unique<OpeningFilter>(m_se);
+}
+
+} // namespace DIPAL

--- a/src/Filters/PrewittFilter.cpp
+++ b/src/Filters/PrewittFilter.cpp
@@ -1,0 +1,115 @@
+// src/Filters/PrewittFilter.cpp
+#include "../../include/DIPAL/Filters/PrewittFilter.hpp"
+#include "../../include/DIPAL/Filters/Kernel.hpp"
+#include "../../include/DIPAL/Image/GrayscaleImage.hpp"
+#include "../../include/DIPAL/Image/ColorImage.hpp"
+#include "../../include/DIPAL/Image/ImageFactory.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <format>
+#include <vector>
+
+namespace DIPAL {
+
+PrewittFilter::PrewittFilter(bool normalize) : m_normalize(normalize) {}
+
+Result<std::unique_ptr<Image>> PrewittFilter::apply(const Image& image) const {
+    const int width  = image.getWidth();
+    const int height = image.getHeight();
+
+    if (width == 0 || height == 0) {
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::InvalidParameter,
+            "Cannot apply Prewitt filter to an empty image");
+    }
+
+    try {
+        std::unique_ptr<GrayscaleImage> gray;
+        if (image.getType() == Image::Type::Grayscale) {
+            auto c = image.clone();
+            gray.reset(static_cast<GrayscaleImage*>(c.release()));
+        } else if (image.getType() == Image::Type::RGB ||
+                   image.getType() == Image::Type::RGBA) {
+            auto r = ImageFactory::toGrayscale(static_cast<const ColorImage&>(image));
+            if (!r)
+                return makeErrorResult<std::unique_ptr<Image>>(
+                    r.error().code(), r.error().message());
+            gray = std::move(r.value());
+        } else {
+            return makeErrorResult<std::unique_ptr<Image>>(
+                ErrorCode::UnsupportedFormat,
+                std::format("PrewittFilter: unsupported image type {}",
+                            static_cast<int>(image.getType())));
+        }
+
+        const Kernel kx = Kernel::prewittX();
+        const Kernel ky = Kernel::prewittY();
+        const int halfW = kx.getHalfWidth();
+        const int halfH = kx.getHalfHeight();
+        const int kW    = kx.getWidth();
+        const int kH    = kx.getHeight();
+
+        std::vector<float> magnitudes(static_cast<size_t>(width * height));
+        float maxMag = 0.0f;
+
+        for (int y = 0; y < height; ++y) {
+            for (int x = 0; x < width; ++x) {
+                float gx = 0.0f, gy = 0.0f;
+                for (int r = 0; r < kH; ++r) {
+                    for (int c = 0; c < kW; ++c) {
+                        const int sy = std::clamp(y + r - halfH, 0, height - 1);
+                        const int sx = std::clamp(x + c - halfW, 0, width  - 1);
+                        auto pr = gray->getPixel(sx, sy);
+                        if (!pr)
+                            return makeErrorResult<std::unique_ptr<Image>>(
+                                pr.error().code(), pr.error().message());
+                        const float p = static_cast<float>(pr.value());
+                        gx += kx.at(r, c) * p;
+                        gy += ky.at(r, c) * p;
+                    }
+                }
+                const float mag = std::sqrt(gx * gx + gy * gy);
+                magnitudes[static_cast<size_t>(y * width + x)] = mag;
+                maxMag = std::max(maxMag, mag);
+            }
+        }
+
+        auto outResult = ImageFactory::createGrayscale(width, height);
+        if (!outResult)
+            return makeErrorResult<std::unique_ptr<Image>>(
+                outResult.error().code(), outResult.error().message());
+        auto& out = *outResult.value();
+
+        for (int y = 0; y < height; ++y) {
+            for (int x = 0; x < width; ++x) {
+                float mag = magnitudes[static_cast<size_t>(y * width + x)];
+                uint8_t val;
+                if (m_normalize && maxMag > 0.0f)
+                    val = static_cast<uint8_t>((mag / maxMag) * 255.0f);
+                else
+                    val = static_cast<uint8_t>(std::min(mag, 255.0f));
+
+                auto sr = out.setPixel(x, y, val);
+                if (!sr)
+                    return makeErrorResult<std::unique_ptr<Image>>(
+                        sr.error().code(), sr.error().message());
+            }
+        }
+
+        return makeSuccessResult<std::unique_ptr<Image>>(std::move(outResult.value()));
+
+    } catch (const std::exception& e) {
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::ProcessingFailed,
+            std::format("PrewittFilter failed: {}", e.what()));
+    }
+}
+
+std::string_view PrewittFilter::getName() const { return "PrewittFilter"; }
+
+std::unique_ptr<FilterStrategy> PrewittFilter::clone() const {
+    return std::make_unique<PrewittFilter>(m_normalize);
+}
+
+} // namespace DIPAL

--- a/src/Filters/RobertsCrossFilter.cpp
+++ b/src/Filters/RobertsCrossFilter.cpp
@@ -1,0 +1,122 @@
+// src/Filters/RobertsCrossFilter.cpp
+#include "../../include/DIPAL/Filters/RobertsCrossFilter.hpp"
+#include "../../include/DIPAL/Filters/Kernel.hpp"
+#include "../../include/DIPAL/Image/GrayscaleImage.hpp"
+#include "../../include/DIPAL/Image/ColorImage.hpp"
+#include "../../include/DIPAL/Image/ImageFactory.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <format>
+#include <vector>
+
+namespace DIPAL {
+
+RobertsCrossFilter::RobertsCrossFilter(bool normalize) : m_normalize(normalize) {}
+
+Result<std::unique_ptr<Image>> RobertsCrossFilter::apply(const Image& image) const {
+    const int width  = image.getWidth();
+    const int height = image.getHeight();
+
+    if (width == 0 || height == 0) {
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::InvalidParameter,
+            "Cannot apply Roberts Cross filter to an empty image");
+    }
+
+    try {
+        std::unique_ptr<GrayscaleImage> gray;
+        if (image.getType() == Image::Type::Grayscale) {
+            auto c = image.clone();
+            gray.reset(static_cast<GrayscaleImage*>(c.release()));
+        } else if (image.getType() == Image::Type::RGB ||
+                   image.getType() == Image::Type::RGBA) {
+            auto r = ImageFactory::toGrayscale(static_cast<const ColorImage&>(image));
+            if (!r)
+                return makeErrorResult<std::unique_ptr<Image>>(
+                    r.error().code(), r.error().message());
+            gray = std::move(r.value());
+        } else {
+            return makeErrorResult<std::unique_ptr<Image>>(
+                ErrorCode::UnsupportedFormat,
+                std::format("RobertsCrossFilter: unsupported image type {}",
+                            static_cast<int>(image.getType())));
+        }
+
+        // Roberts Cross kernels (embedded in 3x3):
+        //  kx = [ 1  0  0]    ky = [ 0  1  0]
+        //       [ 0 -1  0]         [-1  0  0]
+        //       [ 0  0  0]         [ 0  0  0]
+        // Effectively: gx = I(x,y) - I(x+1,y+1)
+        //              gy = I(x+1,y) - I(x,y+1)
+
+        std::vector<float> magnitudes(static_cast<size_t>(width * height));
+        float maxMag = 0.0f;
+
+        for (int y = 0; y < height; ++y) {
+            for (int x = 0; x < width; ++x) {
+                const int x1 = std::min(x + 1, width  - 1);
+                const int y1 = std::min(y + 1, height - 1);
+
+                auto p00r = gray->getPixel(x,  y);
+                auto p11r = gray->getPixel(x1, y1);
+                auto p10r = gray->getPixel(x1, y);
+                auto p01r = gray->getPixel(x,  y1);
+
+                if (!p00r || !p11r || !p10r || !p01r)
+                    return makeErrorResult<std::unique_ptr<Image>>(
+                        ErrorCode::ProcessingFailed,
+                        "RobertsCrossFilter: failed to read pixel");
+
+                const float p00 = static_cast<float>(p00r.value());
+                const float p11 = static_cast<float>(p11r.value());
+                const float p10 = static_cast<float>(p10r.value());
+                const float p01 = static_cast<float>(p01r.value());
+
+                const float gx = p00 - p11;
+                const float gy = p10 - p01;
+                const float mag = std::sqrt(gx * gx + gy * gy);
+
+                magnitudes[static_cast<size_t>(y * width + x)] = mag;
+                maxMag = std::max(maxMag, mag);
+            }
+        }
+
+        auto outResult = ImageFactory::createGrayscale(width, height);
+        if (!outResult)
+            return makeErrorResult<std::unique_ptr<Image>>(
+                outResult.error().code(), outResult.error().message());
+        auto& out = *outResult.value();
+
+        for (int y = 0; y < height; ++y) {
+            for (int x = 0; x < width; ++x) {
+                float mag = magnitudes[static_cast<size_t>(y * width + x)];
+                uint8_t val;
+                if (m_normalize && maxMag > 0.0f)
+                    val = static_cast<uint8_t>((mag / maxMag) * 255.0f);
+                else
+                    val = static_cast<uint8_t>(std::min(mag, 255.0f));
+
+                auto sr = out.setPixel(x, y, val);
+                if (!sr)
+                    return makeErrorResult<std::unique_ptr<Image>>(
+                        sr.error().code(), sr.error().message());
+            }
+        }
+
+        return makeSuccessResult<std::unique_ptr<Image>>(std::move(outResult.value()));
+
+    } catch (const std::exception& e) {
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::ProcessingFailed,
+            std::format("RobertsCrossFilter failed: {}", e.what()));
+    }
+}
+
+std::string_view RobertsCrossFilter::getName() const { return "RobertsCrossFilter"; }
+
+std::unique_ptr<FilterStrategy> RobertsCrossFilter::clone() const {
+    return std::make_unique<RobertsCrossFilter>(m_normalize);
+}
+
+} // namespace DIPAL

--- a/src/Filters/SkeletonFilter.cpp
+++ b/src/Filters/SkeletonFilter.cpp
@@ -1,0 +1,147 @@
+// src/Filters/SkeletonFilter.cpp
+// Zhang-Suen thinning algorithm
+#include "../../include/DIPAL/Filters/SkeletonFilter.hpp"
+#include "../../include/DIPAL/Image/GrayscaleImage.hpp"
+#include "../../include/DIPAL/Image/ColorImage.hpp"
+#include "../../include/DIPAL/Image/ImageFactory.hpp"
+
+#include <algorithm>
+#include <format>
+#include <vector>
+
+namespace DIPAL {
+
+SkeletonFilter::SkeletonFilter(uint8_t threshold) : m_threshold(threshold) {}
+
+Result<std::unique_ptr<Image>> SkeletonFilter::apply(const Image& image) const {
+    const int width  = image.getWidth();
+    const int height = image.getHeight();
+
+    if (width == 0 || height == 0)
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::InvalidParameter, "Cannot skeletonise an empty image");
+
+    try {
+        // Obtain grayscale
+        std::unique_ptr<GrayscaleImage> gray;
+        if (image.getType() == Image::Type::Grayscale) {
+            auto c = image.clone();
+            gray.reset(static_cast<GrayscaleImage*>(c.release()));
+        } else if (image.getType() == Image::Type::RGB ||
+                   image.getType() == Image::Type::RGBA) {
+            auto r = ImageFactory::toGrayscale(static_cast<const ColorImage&>(image));
+            if (!r) return makeErrorResult<std::unique_ptr<Image>>(
+                r.error().code(), r.error().message());
+            gray = std::move(r.value());
+        } else {
+            return makeErrorResult<std::unique_ptr<Image>>(
+                ErrorCode::UnsupportedFormat,
+                std::format("SkeletonFilter: unsupported image type {}",
+                            static_cast<int>(image.getType())));
+        }
+
+        // Binarise into a flat bool grid: true = foreground
+        std::vector<uint8_t> grid(static_cast<size_t>(width * height), 0);
+        for (int y = 0; y < height; ++y) {
+            for (int x = 0; x < width; ++x) {
+                auto pr = gray->getPixel(x, y);
+                if (!pr) return makeErrorResult<std::unique_ptr<Image>>(
+                    pr.error().code(), pr.error().message());
+                grid[static_cast<size_t>(y * width + x)] = (pr.value() >= m_threshold) ? 1 : 0;
+            }
+        }
+
+        // Zhang-Suen iterative thinning
+        // Neighbours in order: P2(top), P3(top-right), P4(right), P5(bottom-right),
+        //                      P6(bottom), P7(bottom-left), P8(left), P9(top-left)
+        const int dx[8] = { 0,  1,  1,  1,  0, -1, -1, -1};
+        const int dy[8] = {-1, -1,  0,  1,  1,  1,  0, -1};
+
+        auto get = [&](int x, int y) -> uint8_t {
+            if (x < 0 || x >= width || y < 0 || y >= height) return 0;
+            return grid[static_cast<size_t>(y * width + x)];
+        };
+
+        bool changed = true;
+        while (changed) {
+            changed = false;
+            for (int iter = 0; iter < 2; ++iter) {
+                std::vector<size_t> toDelete;
+                for (int y = 1; y < height - 1; ++y) {
+                    for (int x = 1; x < width - 1; ++x) {
+                        if (!get(x, y)) continue;
+
+                        // Collect 8-neighbours in order P2..P9
+                        const uint8_t n[8] = {
+                            get(x + dx[0], y + dy[0]),
+                            get(x + dx[1], y + dy[1]),
+                            get(x + dx[2], y + dy[2]),
+                            get(x + dx[3], y + dy[3]),
+                            get(x + dx[4], y + dy[4]),
+                            get(x + dx[5], y + dy[5]),
+                            get(x + dx[6], y + dy[6]),
+                            get(x + dx[7], y + dy[7]),
+                        };
+
+                        // B(P) = number of non-zero neighbours
+                        int B = 0;
+                        for (auto v : n) B += v;
+                        if (B < 2 || B > 6) continue;
+
+                        // A(P) = number of 0→1 transitions in cyclic order P2..P9
+                        int A = 0;
+                        for (int k = 0; k < 8; ++k)
+                            if (!n[k] && n[(k + 1) % 8]) ++A;
+                        if (A != 1) continue;
+
+                        if (iter == 0) {
+                            // Sub-iteration 1: P2·P4·P6 = 0 AND P4·P6·P8 = 0
+                            if (n[0] * n[2] * n[4] != 0) continue;
+                            if (n[2] * n[4] * n[6] != 0) continue;
+                        } else {
+                            // Sub-iteration 2: P2·P4·P8 = 0 AND P2·P6·P8 = 0
+                            if (n[0] * n[2] * n[6] != 0) continue;
+                            if (n[0] * n[4] * n[6] != 0) continue;
+                        }
+
+                        toDelete.push_back(static_cast<size_t>(y * width + x));
+                    }
+                }
+                for (auto idx : toDelete) {
+                    grid[idx] = 0;
+                    changed = true;
+                }
+            }
+        }
+
+        // Write result
+        auto outR = ImageFactory::createGrayscale(width, height);
+        if (!outR) return makeErrorResult<std::unique_ptr<Image>>(
+            outR.error().code(), outR.error().message());
+        auto& out = *outR.value();
+
+        for (int y = 0; y < height; ++y) {
+            for (int x = 0; x < width; ++x) {
+                uint8_t val = grid[static_cast<size_t>(y * width + x)] ? 255 : 0;
+                auto sr = out.setPixel(x, y, val);
+                if (!sr) return makeErrorResult<std::unique_ptr<Image>>(
+                    sr.error().code(), sr.error().message());
+            }
+        }
+
+        return makeSuccessResult<std::unique_ptr<Image>>(std::move(outR.value()));
+
+    } catch (const std::exception& e) {
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::ProcessingFailed,
+            std::format("SkeletonFilter failed: {}", e.what()));
+    }
+}
+
+std::string_view SkeletonFilter::getName() const { return "SkeletonFilter"; }
+
+std::unique_ptr<FilterStrategy> SkeletonFilter::clone() const {
+    return std::make_unique<SkeletonFilter>(m_threshold);
+}
+
+} // namespace DIPAL

--- a/src/Filters/StructuringElement.cpp
+++ b/src/Filters/StructuringElement.cpp
@@ -1,0 +1,87 @@
+// src/Filters/StructuringElement.cpp
+#include "../../include/DIPAL/Filters/StructuringElement.hpp"
+
+#include <stdexcept>
+#include <format>
+#include <cmath>
+
+namespace DIPAL {
+
+StructuringElement::StructuringElement(int width, int height, std::vector<bool> mask)
+    : m_width(width), m_height(height), m_mask(std::move(mask))
+{
+    if (width <= 0 || width % 2 == 0)
+        throw std::invalid_argument(
+            std::format("StructuringElement width must be positive and odd, got {}", width));
+    if (height <= 0 || height % 2 == 0)
+        throw std::invalid_argument(
+            std::format("StructuringElement height must be positive and odd, got {}", height));
+    if (static_cast<int>(m_mask.size()) != width * height)
+        throw std::invalid_argument(
+            std::format("StructuringElement mask size {} != width*height {}",
+                        m_mask.size(), width * height));
+}
+
+StructuringElement StructuringElement::rect(int width, int height) {
+    return StructuringElement(width, height,
+                              std::vector<bool>(static_cast<size_t>(width * height), true));
+}
+
+StructuringElement StructuringElement::ellipse(int width, int height) {
+    if (width <= 0 || width % 2 == 0)
+        throw std::invalid_argument(
+            std::format("Ellipse SE width must be positive and odd, got {}", width));
+    if (height <= 0 || height % 2 == 0)
+        throw std::invalid_argument(
+            std::format("Ellipse SE height must be positive and odd, got {}", height));
+
+    const float cx = (width  - 1) / 2.0f;
+    const float cy = (height - 1) / 2.0f;
+    std::vector<bool> mask(static_cast<size_t>(width * height), false);
+
+    for (int r = 0; r < height; ++r) {
+        for (int c = 0; c < width; ++c) {
+            const float dx = (c - cx) / cx;
+            const float dy = (r - cy) / cy;
+            if (dx * dx + dy * dy <= 1.0f)
+                mask[static_cast<size_t>(r * width + c)] = true;
+        }
+    }
+    return StructuringElement(width, height, std::move(mask));
+}
+
+StructuringElement StructuringElement::cross(int size) {
+    if (size <= 0 || size % 2 == 0)
+        throw std::invalid_argument(
+            std::format("Cross SE size must be positive and odd, got {}", size));
+
+    std::vector<bool> mask(static_cast<size_t>(size * size), false);
+    const int half = size / 2;
+    for (int i = 0; i < size; ++i) {
+        mask[static_cast<size_t>(half * size + i)] = true; // middle row
+        mask[static_cast<size_t>(i    * size + half)] = true; // middle col
+    }
+    return StructuringElement(size, size, std::move(mask));
+}
+
+StructuringElement StructuringElement::diamond(int size) {
+    if (size <= 0 || size % 2 == 0)
+        throw std::invalid_argument(
+            std::format("Diamond SE size must be positive and odd, got {}", size));
+
+    const int half = size / 2;
+    std::vector<bool> mask(static_cast<size_t>(size * size), false);
+    for (int r = 0; r < size; ++r) {
+        for (int c = 0; c < size; ++c) {
+            if (std::abs(r - half) + std::abs(c - half) <= half)
+                mask[static_cast<size_t>(r * size + c)] = true;
+        }
+    }
+    return StructuringElement(size, size, std::move(mask));
+}
+
+StructuringElement StructuringElement::defaultElement() {
+    return rect(3, 3);
+}
+
+} // namespace DIPAL

--- a/src/Filters/TopHatFilter.cpp
+++ b/src/Filters/TopHatFilter.cpp
@@ -1,0 +1,126 @@
+// src/Filters/TopHatFilter.cpp
+#include "../../include/DIPAL/Filters/TopHatFilter.hpp"
+#include "../../include/DIPAL/Filters/OpeningFilter.hpp"
+#include "../../include/DIPAL/Filters/ClosingFilter.hpp"
+#include "../../include/DIPAL/Image/GrayscaleImage.hpp"
+#include "../../include/DIPAL/Image/ColorImage.hpp"
+#include "../../include/DIPAL/Image/ImageFactory.hpp"
+
+#include <algorithm>
+#include <format>
+
+namespace DIPAL {
+
+TopHatFilter::TopHatFilter(Type type, StructuringElement se)
+    : m_type(type), m_se(std::move(se)) {}
+
+Result<std::unique_ptr<Image>> TopHatFilter::apply(const Image& image) const {
+    const int width  = image.getWidth();
+    const int height = image.getHeight();
+
+    if (width == 0 || height == 0)
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::InvalidParameter, "Cannot apply top-hat to empty image");
+
+    // White: original - opening;  Black: closing - original
+    std::unique_ptr<Image> morphed;
+    if (m_type == Type::White) {
+        OpeningFilter op(m_se);
+        auto r = op.apply(image);
+        if (!r) return r;
+        morphed = std::move(r.value());
+    } else {
+        ClosingFilter cl(m_se);
+        auto r = cl.apply(image);
+        if (!r) return r;
+        morphed = std::move(r.value());
+    }
+
+    try {
+        if (image.getType() == Image::Type::Grayscale) {
+            const auto& src  = static_cast<const GrayscaleImage&>(image);
+            const auto& morph = static_cast<const GrayscaleImage&>(*morphed);
+            auto outR = ImageFactory::createGrayscale(width, height);
+            if (!outR) return makeErrorResult<std::unique_ptr<Image>>(
+                outR.error().code(), outR.error().message());
+            auto& out = *outR.value();
+
+            for (int y = 0; y < height; ++y) {
+                for (int x = 0; x < width; ++x) {
+                    auto sp = src.getPixel(x, y);
+                    auto mp = morph.getPixel(x, y);
+                    if (!sp || !mp) return makeErrorResult<std::unique_ptr<Image>>(
+                        ErrorCode::ProcessingFailed, "Failed to read pixel");
+
+                    uint8_t val;
+                    if (m_type == Type::White)
+                        val = static_cast<uint8_t>(
+                            std::max(0, static_cast<int>(sp.value()) - mp.value()));
+                    else
+                        val = static_cast<uint8_t>(
+                            std::max(0, static_cast<int>(mp.value()) - sp.value()));
+
+                    auto sr = out.setPixel(x, y, val);
+                    if (!sr) return makeErrorResult<std::unique_ptr<Image>>(
+                        sr.error().code(), sr.error().message());
+                }
+            }
+            return makeSuccessResult<std::unique_ptr<Image>>(std::move(outR.value()));
+        }
+
+        if (image.getType() == Image::Type::RGB || image.getType() == Image::Type::RGBA) {
+            const auto& src   = static_cast<const ColorImage&>(image);
+            const auto& morph = static_cast<const ColorImage&>(*morphed);
+            const bool  hasA  = (image.getType() == Image::Type::RGBA);
+            auto outR = ImageFactory::createColor(width, height, hasA);
+            if (!outR) return makeErrorResult<std::unique_ptr<Image>>(
+                outR.error().code(), outR.error().message());
+            auto& out = *outR.value();
+
+            for (int y = 0; y < height; ++y) {
+                for (int x = 0; x < width; ++x) {
+                    uint8_t sr2, sg, sb, sa, mr, mg, mb, ma;
+                    auto sp = src.getPixel(x, y, sr2, sg, sb, sa);
+                    auto mp = morph.getPixel(x, y, mr, mg, mb, ma);
+                    if (!sp || !mp) return makeErrorResult<std::unique_ptr<Image>>(
+                        ErrorCode::ProcessingFailed, "Failed to read pixel");
+
+                    uint8_t outR2, outG, outB;
+                    if (m_type == Type::White) {
+                        outR2 = static_cast<uint8_t>(std::max(0, static_cast<int>(sr2) - mr));
+                        outG  = static_cast<uint8_t>(std::max(0, static_cast<int>(sg)  - mg));
+                        outB  = static_cast<uint8_t>(std::max(0, static_cast<int>(sb)  - mb));
+                    } else {
+                        outR2 = static_cast<uint8_t>(std::max(0, static_cast<int>(mr) - sr2));
+                        outG  = static_cast<uint8_t>(std::max(0, static_cast<int>(mg) - sg));
+                        outB  = static_cast<uint8_t>(std::max(0, static_cast<int>(mb) - sb));
+                    }
+                    auto sr = out.setPixel(x, y, outR2, outG, outB, sa);
+                    if (!sr) return makeErrorResult<std::unique_ptr<Image>>(
+                        sr.error().code(), sr.error().message());
+                }
+            }
+            return makeSuccessResult<std::unique_ptr<Image>>(std::move(outR.value()));
+        }
+
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::UnsupportedFormat,
+            std::format("TopHatFilter: unsupported image type {}",
+                        static_cast<int>(image.getType())));
+
+    } catch (const std::exception& e) {
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::ProcessingFailed,
+            std::format("TopHatFilter failed: {}", e.what()));
+    }
+}
+
+std::string_view TopHatFilter::getName() const {
+    return m_type == Type::White ? "WhiteTopHatFilter" : "BlackTopHatFilter";
+}
+
+std::unique_ptr<FilterStrategy> TopHatFilter::clone() const {
+    return std::make_unique<TopHatFilter>(m_type, m_se);
+}
+
+} // namespace DIPAL


### PR DESCRIPTION
## Summary

Implements three interconnected feature sets for v0.2.0, all building on a shared convolution/structuring-element foundation.

- **Convolution framework** — `Kernel` value type with 10 factory shapes + `ConvolutionFilter` with 4 border modes (Clamp, Reflect, Wrap, Zero), works on grayscale and per-channel colour
- **Edge detection filters** — `LaplacianFilter` (4/8-neighbour), `PrewittFilter`, `RobertsCrossFilter`, `CannyFilter` (full 4-stage: Gaussian smooth → Sobel gradients → non-maximum suppression → BFS hysteresis)
- **Morphological operations** — `StructuringElement` (Rect/Ellipse/Cross/Diamond), `ErosionFilter`, `DilationFilter`, `OpeningFilter`, `ClosingFilter`, `MorphologicalGradientFilter`, `TopHatFilter` (White/Black), `HitOrMissFilter`, `SkeletonFilter` (Zhang-Suen thinning)

All new types are exposed through `DIPAL.hpp` and `Filters.hpp`. Closes #39 and #40.

## Stats

- 3 commits, 33 files changed, +2405 / -32 lines
- All 54 existing tests pass

## Test plan

- [ ] Build passes on Linux (`cmake --build build -j$(nproc)`)
- [ ] All 54 tests pass (`ctest --test-dir build`)
- [ ] Smoke-test `ConvolutionFilter` with `Kernel::sharpen()` on a grayscale image
- [ ] Smoke-test `CannyFilter` on a grayscale image — verify binary edge output
- [ ] Smoke-test `ErosionFilter` / `DilationFilter` — verify min/max neighbourhood behaviour
- [ ] Smoke-test `SkeletonFilter` — verify thinning produces 1-pixel-wide result