### PR TITLE
feat: Add BilateralFilter, HighPassFilter, LowPassFilter

### DIFF
--- a/include/DIPAL/DIPAL.hpp
+++ b/include/DIPAL/DIPAL.hpp
@@ -39,6 +39,9 @@
 #include "Filters/TopHatFilter.hpp"
 #include "Filters/HitOrMissFilter.hpp"
 #include "Filters/SkeletonFilter.hpp"
+#include "Filters/BilateralFilter.hpp"
+#include "Filters/HighPassFilter.hpp"
+#include "Filters/LowPassFilter.hpp"
 
 // I/O Includes
 #include "IO/BMPImageIO.hpp"

--- a/include/DIPAL/Filters/BilateralFilter.hpp
+++ b/include/DIPAL/Filters/BilateralFilter.hpp
@@ -1,0 +1,42 @@
+// include/DIPAL/Filters/BilateralFilter.hpp
+#ifndef DIPAL_BILATERAL_FILTER_HPP
+#define DIPAL_BILATERAL_FILTER_HPP
+
+#include "FilterStrategy.hpp"
+
+namespace DIPAL {
+
+/**
+ * @brief Bilateral filter (edge-preserving smoothing)
+ *
+ * Combines a spatial Gaussian weight (distance in pixels) with a range
+ * Gaussian weight (difference in intensity) so that edges are preserved
+ * while flat regions are smoothed.
+ *
+ * Works on grayscale and colour images (per-channel range weight).
+ */
+class BilateralFilter : public FilterStrategy {
+public:
+    /**
+     * @param diameter    Diameter of the pixel neighbourhood (must be odd; 0 = auto from sigmaSpace)
+     * @param sigmaColor  Gaussian standard deviation in the intensity/colour domain
+     * @param sigmaSpace  Gaussian standard deviation in the spatial domain (pixels)
+     */
+    BilateralFilter(int diameter = 0, float sigmaColor = 75.0f, float sigmaSpace = 75.0f);
+
+    [[nodiscard]] Result<std::unique_ptr<Image>> apply(const Image& image) const override;
+    [[nodiscard]] std::string_view getName() const override;
+    [[nodiscard]] std::unique_ptr<FilterStrategy> clone() const override;
+
+    [[nodiscard]] int   getDiameter()   const noexcept { return m_diameter; }
+    [[nodiscard]] float getSigmaColor() const noexcept { return m_sigmaColor; }
+    [[nodiscard]] float getSigmaSpace() const noexcept { return m_sigmaSpace; }
+
+private:
+    int   m_diameter;
+    float m_sigmaColor;
+    float m_sigmaSpace;
+};
+
+} // namespace DIPAL
+#endif // DIPAL_BILATERAL_FILTER_HPP

--- a/include/DIPAL/Filters/Filters.hpp
+++ b/include/DIPAL/Filters/Filters.hpp
@@ -22,5 +22,8 @@
 #include "TopHatFilter.hpp"
 #include "HitOrMissFilter.hpp"
 #include "SkeletonFilter.hpp"
+#include "BilateralFilter.hpp"
+#include "HighPassFilter.hpp"
+#include "LowPassFilter.hpp"
 
 #endif  // DIPAL_FILTERS_HPP

--- a/include/DIPAL/Filters/HighPassFilter.hpp
+++ b/include/DIPAL/Filters/HighPassFilter.hpp
@@ -1,0 +1,37 @@
+// include/DIPAL/Filters/HighPassFilter.hpp
+#ifndef DIPAL_HIGH_PASS_FILTER_HPP
+#define DIPAL_HIGH_PASS_FILTER_HPP
+
+#include "FilterStrategy.hpp"
+
+namespace DIPAL {
+
+/**
+ * @brief High-pass filter  (original − Gaussian blur + 128 bias)
+ *
+ * Subtracts a Gaussian-blurred version from the original to retain only
+ * high-frequency detail. A 128-bias centres the result around mid-grey.
+ * Works on grayscale and colour images.
+ */
+class HighPassFilter : public FilterStrategy {
+public:
+    /**
+     * @param sigma      Standard deviation of the subtracted Gaussian blur
+     * @param kernelSize Gaussian kernel size (0 = auto from sigma)
+     */
+    explicit HighPassFilter(float sigma = 1.0f, int kernelSize = 0);
+
+    [[nodiscard]] Result<std::unique_ptr<Image>> apply(const Image& image) const override;
+    [[nodiscard]] std::string_view getName() const override;
+    [[nodiscard]] std::unique_ptr<FilterStrategy> clone() const override;
+
+    [[nodiscard]] float getSigma()      const noexcept { return m_sigma; }
+    [[nodiscard]] int   getKernelSize() const noexcept { return m_kernelSize; }
+
+private:
+    float m_sigma;
+    int   m_kernelSize;
+};
+
+} // namespace DIPAL
+#endif // DIPAL_HIGH_PASS_FILTER_HPP

--- a/include/DIPAL/Filters/LowPassFilter.hpp
+++ b/include/DIPAL/Filters/LowPassFilter.hpp
@@ -1,0 +1,37 @@
+// include/DIPAL/Filters/LowPassFilter.hpp
+#ifndef DIPAL_LOW_PASS_FILTER_HPP
+#define DIPAL_LOW_PASS_FILTER_HPP
+
+#include "FilterStrategy.hpp"
+
+namespace DIPAL {
+
+/**
+ * @brief Low-pass filter  (Gaussian blur)
+ *
+ * Attenuates high-frequency components by applying a Gaussian blur.
+ * This is a named alias that makes intent explicit in processing pipelines.
+ * Works on grayscale and colour images.
+ */
+class LowPassFilter : public FilterStrategy {
+public:
+    /**
+     * @param sigma      Standard deviation of the Gaussian kernel
+     * @param kernelSize Kernel size (0 = auto from sigma)
+     */
+    explicit LowPassFilter(float sigma = 1.0f, int kernelSize = 0);
+
+    [[nodiscard]] Result<std::unique_ptr<Image>> apply(const Image& image) const override;
+    [[nodiscard]] std::string_view getName() const override;
+    [[nodiscard]] std::unique_ptr<FilterStrategy> clone() const override;
+
+    [[nodiscard]] float getSigma()      const noexcept { return m_sigma; }
+    [[nodiscard]] int   getKernelSize() const noexcept { return m_kernelSize; }
+
+private:
+    float m_sigma;
+    int   m_kernelSize;
+};
+
+} // namespace DIPAL
+#endif // DIPAL_LOW_PASS_FILTER_HPP

--- a/src/Filters/BilateralFilter.cpp
+++ b/src/Filters/BilateralFilter.cpp
@@ -1,0 +1,157 @@
+// src/Filters/BilateralFilter.cpp
+#include "../../include/DIPAL/Filters/BilateralFilter.hpp"
+#include "../../include/DIPAL/Image/GrayscaleImage.hpp"
+#include "../../include/DIPAL/Image/ColorImage.hpp"
+#include "../../include/DIPAL/Image/ImageFactory.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <format>
+#include <vector>
+
+namespace DIPAL {
+
+BilateralFilter::BilateralFilter(int diameter, float sigmaColor, float sigmaSpace)
+    : m_diameter(diameter), m_sigmaColor(sigmaColor), m_sigmaSpace(sigmaSpace)
+{
+    if (sigmaColor <= 0.0f)
+        throw std::invalid_argument(
+            std::format("BilateralFilter: sigmaColor must be positive, got {}", sigmaColor));
+    if (sigmaSpace <= 0.0f)
+        throw std::invalid_argument(
+            std::format("BilateralFilter: sigmaSpace must be positive, got {}", sigmaSpace));
+}
+
+Result<std::unique_ptr<Image>> BilateralFilter::apply(const Image& image) const {
+    const int width  = image.getWidth();
+    const int height = image.getHeight();
+
+    if (width == 0 || height == 0)
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::InvalidParameter, "Cannot apply bilateral filter to empty image");
+
+    // Determine actual diameter
+    int d = m_diameter;
+    if (d <= 0)
+        d = static_cast<int>(std::ceil(2.0f * m_sigmaSpace * 3.0f)) | 1;
+    if (d % 2 == 0) ++d;
+    const int half = d / 2;
+
+    // Pre-compute spatial weights (only depend on distance, same for every pixel)
+    const float twoSigSpace2 = 2.0f * m_sigmaSpace * m_sigmaSpace;
+    std::vector<float> spatialW(static_cast<size_t>(d * d));
+    for (int dy = -half; dy <= half; ++dy)
+        for (int dx = -half; dx <= half; ++dx)
+            spatialW[static_cast<size_t>((dy + half) * d + (dx + half))] =
+                std::exp(-(dx * dx + dy * dy) / twoSigSpace2);
+
+    const float twoSigColor2 = 2.0f * m_sigmaColor * m_sigmaColor;
+
+    try {
+        if (image.getType() == Image::Type::Grayscale) {
+            const auto& src = static_cast<const GrayscaleImage&>(image);
+            auto outR = ImageFactory::createGrayscale(width, height);
+            if (!outR) return makeErrorResult<std::unique_ptr<Image>>(
+                outR.error().code(), outR.error().message());
+            auto& out = *outR.value();
+
+            for (int y = 0; y < height; ++y) {
+                for (int x = 0; x < width; ++x) {
+                    auto cp = src.getPixel(x, y);
+                    if (!cp) return makeErrorResult<std::unique_ptr<Image>>(
+                        cp.error().code(), cp.error().message());
+                    const float center = static_cast<float>(cp.value());
+
+                    float wSum = 0.0f, valSum = 0.0f;
+                    for (int dy = -half; dy <= half; ++dy) {
+                        for (int dx = -half; dx <= half; ++dx) {
+                            const int sy = std::clamp(y + dy, 0, height - 1);
+                            const int sx = std::clamp(x + dx, 0, width  - 1);
+                            auto np = src.getPixel(sx, sy);
+                            if (!np) continue;
+                            const float n = static_cast<float>(np.value());
+                            const float diff = n - center;
+                            const float rangeW = std::exp(-(diff * diff) / twoSigColor2);
+                            const float w = spatialW[static_cast<size_t>(
+                                (dy + half) * d + (dx + half))] * rangeW;
+                            valSum += w * n;
+                            wSum   += w;
+                        }
+                    }
+                    const uint8_t val = static_cast<uint8_t>(
+                        std::clamp(std::round(valSum / wSum), 0.0f, 255.0f));
+                    auto sr = out.setPixel(x, y, val);
+                    if (!sr) return makeErrorResult<std::unique_ptr<Image>>(
+                        sr.error().code(), sr.error().message());
+                }
+            }
+            return makeSuccessResult<std::unique_ptr<Image>>(std::move(outR.value()));
+        }
+
+        if (image.getType() == Image::Type::RGB || image.getType() == Image::Type::RGBA) {
+            const auto& src  = static_cast<const ColorImage&>(image);
+            const bool  hasA = (image.getType() == Image::Type::RGBA);
+            auto outR = ImageFactory::createColor(width, height, hasA);
+            if (!outR) return makeErrorResult<std::unique_ptr<Image>>(
+                outR.error().code(), outR.error().message());
+            auto& out = *outR.value();
+
+            for (int y = 0; y < height; ++y) {
+                for (int x = 0; x < width; ++x) {
+                    uint8_t cr, cg, cb, ca;
+                    auto cp = src.getPixel(x, y, cr, cg, cb, ca);
+                    if (!cp) return makeErrorResult<std::unique_ptr<Image>>(
+                        cp.error().code(), cp.error().message());
+                    const float fc = static_cast<float>(cr);
+                    const float gc = static_cast<float>(cg);
+                    const float bc = static_cast<float>(cb);
+
+                    float wSum = 0.0f, rSum = 0.0f, gSum = 0.0f, bSum = 0.0f;
+                    for (int dy = -half; dy <= half; ++dy) {
+                        for (int dx = -half; dx <= half; ++dx) {
+                            const int sy = std::clamp(y + dy, 0, height - 1);
+                            const int sx = std::clamp(x + dx, 0, width  - 1);
+                            uint8_t nr, ng, nb, na;
+                            auto np = src.getPixel(sx, sy, nr, ng, nb, na);
+                            if (!np) continue;
+                            const float dr = nr - fc, dg = ng - gc, db = nb - bc;
+                            const float colorDist2 = dr*dr + dg*dg + db*db;
+                            const float rangeW = std::exp(-colorDist2 / twoSigColor2);
+                            const float w = spatialW[static_cast<size_t>(
+                                (dy + half) * d + (dx + half))] * rangeW;
+                            rSum += w * nr;
+                            gSum += w * ng;
+                            bSum += w * nb;
+                            wSum += w;
+                        }
+                    }
+                    const auto toU8 = [](float v) {
+                        return static_cast<uint8_t>(std::clamp(std::round(v), 0.0f, 255.0f));
+                    };
+                    auto sr = out.setPixel(x, y, toU8(rSum/wSum), toU8(gSum/wSum), toU8(bSum/wSum), ca);
+                    if (!sr) return makeErrorResult<std::unique_ptr<Image>>(
+                        sr.error().code(), sr.error().message());
+                }
+            }
+            return makeSuccessResult<std::unique_ptr<Image>>(std::move(outR.value()));
+        }
+
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::UnsupportedFormat,
+            std::format("BilateralFilter: unsupported image type {}",
+                        static_cast<int>(image.getType())));
+
+    } catch (const std::exception& e) {
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::ProcessingFailed,
+            std::format("BilateralFilter failed: {}", e.what()));
+    }
+}
+
+std::string_view BilateralFilter::getName() const { return "BilateralFilter"; }
+
+std::unique_ptr<FilterStrategy> BilateralFilter::clone() const {
+    return std::make_unique<BilateralFilter>(m_diameter, m_sigmaColor, m_sigmaSpace);
+}
+
+} // namespace DIPAL

--- a/src/Filters/HighPassFilter.cpp
+++ b/src/Filters/HighPassFilter.cpp
@@ -1,0 +1,113 @@
+// src/Filters/HighPassFilter.cpp
+#include "../../include/DIPAL/Filters/HighPassFilter.hpp"
+#include "../../include/DIPAL/Filters/GaussianBlurFilter.hpp"
+#include "../../include/DIPAL/Image/GrayscaleImage.hpp"
+#include "../../include/DIPAL/Image/ColorImage.hpp"
+#include "../../include/DIPAL/Image/ImageFactory.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <format>
+
+namespace DIPAL {
+
+HighPassFilter::HighPassFilter(float sigma, int kernelSize)
+    : m_sigma(sigma), m_kernelSize(kernelSize)
+{
+    if (sigma <= 0.0f)
+        throw std::invalid_argument(
+            std::format("HighPassFilter: sigma must be positive, got {}", sigma));
+}
+
+Result<std::unique_ptr<Image>> HighPassFilter::apply(const Image& image) const {
+    const int width  = image.getWidth();
+    const int height = image.getHeight();
+
+    if (width == 0 || height == 0)
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::InvalidParameter, "Cannot apply high-pass filter to empty image");
+
+    int kSize = m_kernelSize;
+    if (kSize <= 0) kSize = static_cast<int>(std::ceil(6.0f * m_sigma)) | 1;
+    if (kSize % 2 == 0) ++kSize;
+
+    // Compute blurred version
+    GaussianBlurFilter blur(m_sigma, kSize);
+    auto blurResult = blur.apply(image);
+    if (!blurResult) return blurResult;
+
+    // high-pass = original - blurred + 128  (per channel)
+    try {
+        if (image.getType() == Image::Type::Grayscale) {
+            const auto& src = static_cast<const GrayscaleImage&>(image);
+            const auto& low = static_cast<const GrayscaleImage&>(*blurResult.value());
+            auto outR = ImageFactory::createGrayscale(width, height);
+            if (!outR) return makeErrorResult<std::unique_ptr<Image>>(
+                outR.error().code(), outR.error().message());
+            auto& out = *outR.value();
+
+            for (int y = 0; y < height; ++y) {
+                for (int x = 0; x < width; ++x) {
+                    auto sp = src.getPixel(x, y);
+                    auto lp = low.getPixel(x, y);
+                    if (!sp || !lp) return makeErrorResult<std::unique_ptr<Image>>(
+                        ErrorCode::ProcessingFailed, "Failed to read pixel");
+                    const int val = static_cast<int>(sp.value()) - lp.value() + 128;
+                    auto sr = out.setPixel(x, y,
+                        static_cast<uint8_t>(std::clamp(val, 0, 255)));
+                    if (!sr) return makeErrorResult<std::unique_ptr<Image>>(
+                        sr.error().code(), sr.error().message());
+                }
+            }
+            return makeSuccessResult<std::unique_ptr<Image>>(std::move(outR.value()));
+        }
+
+        if (image.getType() == Image::Type::RGB || image.getType() == Image::Type::RGBA) {
+            const auto& src  = static_cast<const ColorImage&>(image);
+            const auto& low  = static_cast<const ColorImage&>(*blurResult.value());
+            const bool  hasA = (image.getType() == Image::Type::RGBA);
+            auto outR = ImageFactory::createColor(width, height, hasA);
+            if (!outR) return makeErrorResult<std::unique_ptr<Image>>(
+                outR.error().code(), outR.error().message());
+            auto& out = *outR.value();
+
+            for (int y = 0; y < height; ++y) {
+                for (int x = 0; x < width; ++x) {
+                    uint8_t sr2, sg, sb, sa, lr, lg, lb, la;
+                    auto sp = src.getPixel(x, y, sr2, sg, sb, sa);
+                    auto lp = low.getPixel(x, y, lr, lg, lb, la);
+                    if (!sp || !lp) return makeErrorResult<std::unique_ptr<Image>>(
+                        ErrorCode::ProcessingFailed, "Failed to read pixel");
+                    const auto clamp8 = [](int v) {
+                        return static_cast<uint8_t>(std::clamp(v, 0, 255));
+                    };
+                    auto res = out.setPixel(x, y,
+                        clamp8(sr2 - lr + 128),
+                        clamp8(sg  - lg + 128),
+                        clamp8(sb  - lb + 128), sa);
+                    if (!res) return makeErrorResult<std::unique_ptr<Image>>(
+                        res.error().code(), res.error().message());
+                }
+            }
+            return makeSuccessResult<std::unique_ptr<Image>>(std::move(outR.value()));
+        }
+
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::UnsupportedFormat,
+            std::format("HighPassFilter: unsupported image type {}",
+                        static_cast<int>(image.getType())));
+
+    } catch (const std::exception& e) {
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::ProcessingFailed,
+            std::format("HighPassFilter failed: {}", e.what()));
+    }
+}
+
+std::string_view HighPassFilter::getName() const { return "HighPassFilter"; }
+
+std::unique_ptr<FilterStrategy> HighPassFilter::clone() const {
+    return std::make_unique<HighPassFilter>(m_sigma, m_kernelSize);
+}
+
+} // namespace DIPAL

--- a/src/Filters/LowPassFilter.cpp
+++ b/src/Filters/LowPassFilter.cpp
@@ -1,0 +1,37 @@
+// src/Filters/LowPassFilter.cpp
+#include "../../include/DIPAL/Filters/LowPassFilter.hpp"
+#include "../../include/DIPAL/Filters/GaussianBlurFilter.hpp"
+
+#include <cmath>
+#include <format>
+
+namespace DIPAL {
+
+LowPassFilter::LowPassFilter(float sigma, int kernelSize)
+    : m_sigma(sigma), m_kernelSize(kernelSize)
+{
+    if (sigma <= 0.0f)
+        throw std::invalid_argument(
+            std::format("LowPassFilter: sigma must be positive, got {}", sigma));
+}
+
+Result<std::unique_ptr<Image>> LowPassFilter::apply(const Image& image) const {
+    if (image.getWidth() == 0 || image.getHeight() == 0)
+        return makeErrorResult<std::unique_ptr<Image>>(
+            ErrorCode::InvalidParameter, "Cannot apply low-pass filter to empty image");
+
+    int kSize = m_kernelSize;
+    if (kSize <= 0) kSize = static_cast<int>(std::ceil(6.0f * m_sigma)) | 1;
+    if (kSize % 2 == 0) ++kSize;
+
+    GaussianBlurFilter blur(m_sigma, kSize);
+    return blur.apply(image);
+}
+
+std::string_view LowPassFilter::getName() const { return "LowPassFilter"; }
+
+std::unique_ptr<FilterStrategy> LowPassFilter::clone() const {
+    return std::make_unique<LowPassFilter>(m_sigma, m_kernelSize);
+}
+
+} // namespace DIPAL


### PR DESCRIPTION
## Summary

Completes issue #41 by adding the three remaining filter types:

- **BilateralFilter** — edge-preserving smoothing via joint spatial + range Gaussian weights; configurable `diameter`, `sigmaColor`, `sigmaSpace`; works on grayscale and per-channel colour
- **HighPassFilter** — `original − Gaussian blur + 128`; retains high-frequency detail while centring output around mid-grey
- **LowPassFilter** — named alias over `GaussianBlurFilter`; makes intent explicit in processing pipelines

Closes #41.

## Stats

- 1 commit, 8 files, +429 lines
- All 54 existing tests pass

## Test plan

- [ ] Build passes (`cmake --build build -j$(nproc)`)
- [ ] All 54 tests pass (`ctest --test-dir build`)
- [ ] `BilateralFilter` on a noisy image — edges sharp, flat regions smooth
- [ ] `HighPassFilter` output centres around 128 on a flat image
- [ ] `LowPassFilter` output matches `GaussianBlurFilter` with same sigma